### PR TITLE
Update getScanResults example (scan=123456)

### DIFF
--- a/httpobs/docs/api.md
+++ b/httpobs/docs/api.md
@@ -60,7 +60,7 @@ Parameters:
 
 Example:
 
-* `/api/v1/getScanResults?scan_id=123456`
+* `/api/v1/getScanResults?scan=123456`
 
 ### Retrieve recent scans
 


### PR DESCRIPTION
The query string argument is `scan` not `scan_id` :-)

https://github.com/mozilla/http-observatory/blob/master/httpobs/website/api.py#L103