### PR TITLE
Make style src only csp pass

### DIFF
--- a/httpobs/scanner/analyzer/headers.py
+++ b/httpobs/scanner/analyzer/headers.py
@@ -85,7 +85,9 @@ def content_security_policy(reqs: dict, expectation='csp-implemented-with-no-uns
         output['result'] = 'csp-not-implemented'
 
     # Check to see if the test passed or failed
-    if output['result'] in (expectation, 'csp-implemented-with-no-unsafe-default-src-none'):
+    if output['result'] in (expectation,
+                            'csp-implemented-with-no-unsafe-default-src-none',
+                            'csp-implemented-with-unsafe-inline-in-style-src-only'):
         output['pass'] = True
 
     return output

--- a/httpobs/tests/unittests/test_headers.py
+++ b/httpobs/tests/unittests/test_headers.py
@@ -75,7 +75,7 @@ class TestContentSecurityPolicy(TestCase):
             result = content_security_policy(self.reqs)
 
             self.assertEquals('csp-implemented-with-unsafe-inline-in-style-src-only', result['result'])
-            self.assertFalse(result['pass'])
+            self.assertTrue(result['pass'])
 
     def test_no_unsafe(self):
         values = ("default-src https://mozilla.org",


### PR DESCRIPTION
It was confusing as it was -- a score of 0 and a failing grade.  I'm setting it to pass for now until I can think of something better.