### PR TITLE
do not compare case when comparing HTTPS redirect URL

### DIFF
--- a/httpobs/scanner/analyzer/misc.py
+++ b/httpobs/scanner/analyzer/misc.py
@@ -150,7 +150,7 @@ def redirection(reqs: dict, expectation='redirection-to-https') -> dict:
         # If it's an http -> https redirection, make sure it redirects to the same host. If that's not done, then
         # HSTS cannot be properly set on the original host
         elif (urlparse(output['route'][0]).scheme == 'http' and urlparse(output['route'][1]).scheme == 'https' and
-              urlparse(output['route'][0]).netloc != urlparse(output['route'][1]).netloc):
+              urlparse(output['route'][0]).netloc.lower() != urlparse(output['route'][1]).netloc.lower()):
             output['result'] = 'redirection-off-host-from-http'
             output['status_code'] = response.history[-1].status_code
         else:


### PR DESCRIPTION
Error: HTTP does not redirect to HTTPS`http://bugs.freebsd.org` (HTTP) redirects to `https://bugs.FreeBSD.org/`. The first redirect from `http://bugs.freebsd.org` should be to a secure page on the same host (`https://bugs.freebsd.org`).