### PR TITLE
Fix where no HttpOnly was treated worse than no Secure, on session cookies

### DIFF
--- a/httpobs/scanner/analyzer/headers.py
+++ b/httpobs/scanner/analyzer/headers.py
@@ -124,8 +124,8 @@ def cookies(reqs: dict, expectation='cookies-secure-with-httponly-sessions') -> 
     goodness = ['cookies-without-secure-flag-but-protected-by-hsts',
                 'cookies-without-secure-flag',
                 'cookies-session-without-secure-flag-but-protected-by-hsts',
-                'cookies-session-without-secure-flag',
-                'cookies-session-without-httponly-flag']
+                'cookies-session-without-httponly-flag',
+                'cookies-session-without-secure-flag']
 
     # Get their HTTP Strict Transport Security status, which can help when cookies are set without Secure
     hsts = strict_transport_security(reqs)['pass']

--- a/httpobs/tests/unittests/test_headers.py
+++ b/httpobs/tests/unittests/test_headers.py
@@ -130,7 +130,7 @@ class TestCookies(TestCase):
                         port=443,
                         port_specified=443,
                         rfc2109=False,
-                        rest={'HttpOnly': None},
+                        rest={'HttpOnly': True},
                         secure=True,
                         version=1,
                         value='bar')
@@ -174,7 +174,7 @@ class TestCookies(TestCase):
                         port=443,
                         port_specified=443,
                         rfc2109=False,
-                        rest={'HttpOnly': None},
+                        rest={},
                         secure=False,
                         version=1,
                         value='bar')
@@ -200,7 +200,7 @@ class TestCookies(TestCase):
                         port=443,
                         port_specified=443,
                         rfc2109=False,
-                        rest={'HttpOnly': None},
+                        rest={'HttpOnly': True},
                         secure=False,
                         version=1,
                         value='bar')
@@ -226,7 +226,7 @@ class TestCookies(TestCase):
                         port=443,
                         port_specified=443,
                         rfc2109=False,
-                        rest={'HttpOnly': None},
+                        rest={},
                         secure=False,
                         version=1,
                         value='bar')
@@ -276,7 +276,7 @@ class TestCookies(TestCase):
                         port=443,
                         port_specified=443,
                         rfc2109=False,
-                        rest={'HttpOnly': None},
+                        rest={'HttpOnly': True},
                         secure=False,
                         version=1,
                         value='bar')
@@ -287,6 +287,30 @@ class TestCookies(TestCase):
         self.assertEquals('cookies-session-without-secure-flag', result['result'])
         self.assertFalse(result['pass'])
 
+        # https://github.com/mozilla/http-observatory/issues/97
+        cookie = Cookie(name='SESSIONID',
+                        comment=None,
+                        comment_url=None,
+                        discard=False,
+                        domain='mozilla.com',
+                        domain_initial_dot=False,
+                        domain_specified='mozilla.com',
+                        expires=None,
+                        path='/',
+                        path_specified='/',
+                        port=443,
+                        port_specified=443,
+                        rfc2109=False,
+                        rest={},
+                        secure=False,
+                        version=1,
+                        value='bar')
+        self.reqs['session'].cookies.set_cookie(cookie)
+
+        result = cookies(self.reqs)
+
+        self.assertEquals('cookies-session-without-secure-flag', result['result'])
+        self.assertFalse(result['pass'])
 
 class TestPublicKeyPinning(TestCase):
     def setUp(self):

--- a/httpobs/tests/unittests/test_headers.py
+++ b/httpobs/tests/unittests/test_headers.py
@@ -312,6 +312,7 @@ class TestCookies(TestCase):
         self.assertEquals('cookies-session-without-secure-flag', result['result'])
         self.assertFalse(result['pass'])
 
+
 class TestPublicKeyPinning(TestCase):
     def setUp(self):
         self.reqs = empty_requests()


### PR DESCRIPTION
Fixes #97.