### PR TITLE
Don't penalize 'unsafe-inline' if hash or nonce source is used

### DIFF
--- a/httpobs/scanner/analyzer/headers.py
+++ b/httpobs/scanner/analyzer/headers.py
@@ -58,7 +58,11 @@ def content_security_policy(reqs: dict, expectation='csp-implemented-with-no-uns
         for directive in ['script-src', 'style-src']:
             csp[directive] = csp.get(directive) if directive in csp else csp.get('default-src')
 
-        # TODO: remove 'unsafe-inline' or 'unsafe-eval' if nonce or hash are used
+        # Remove 'unsafe-inline' if nonce or hash are used are in script-src
+        # See: https://github.com/mozilla/http-observatory/issues/88
+        if any(source.startswith(('\'sha256-', '\'sha384-', '\'sha512-', '\'nonce-'))
+               for source in csp.get('script-src', ())):
+            csp['script-src'] = [source for source in csp['script-src'] if source != '\'unsafe-inline\'']
 
         # Do all of our tests
         if '\'unsafe-inline\'' in csp.get('script-src') or 'data:' in csp.get('script-src'):

--- a/httpobs/tests/unittests/test_headers.py
+++ b/httpobs/tests/unittests/test_headers.py
@@ -78,8 +78,12 @@ class TestContentSecurityPolicy(TestCase):
             self.assertTrue(result['pass'])
 
     def test_no_unsafe(self):
+        # See https://github.com/mozilla/http-observatory/issues/88 for 'unsafe-inline' + hash/nonce
         values = ("default-src https://mozilla.org",
-                  "script-src https://mozilla.org; style-src https://mozilla.org; upgrade-insecure-requests;")
+                  "script-src https://mozilla.org; style-src https://mozilla.org; upgrade-insecure-requests;",
+                  "script-src 'unsafe-inline' 'sha256-hqBEA/HXB3aJU2FgOnYN8rkAgEVgyfi3Vs1j2/XMPBA='" +
+                  'sha256-hqBEA/HXB3aJU2FgOnYN8rkAgEVgyfi3Vs1j2/XMPBB=',
+                  "script-src 'unsafe-inline' 'nonce-abc123' 'unsafe-inline'")
 
         for value in values:
             self.reqs['responses']['auto'].headers['Content-Security-Policy'] = value


### PR DESCRIPTION
Fixes #88.