### PR TITLE
Add support for mapping grades to Mozilla likelihood indicator (risk framework)

### DIFF
--- a/httpobs/database/database.py
+++ b/httpobs/database/database.py
@@ -14,7 +14,7 @@ from httpobs.conf import (API_CACHED_RESULT_TIME,
                           SCANNER_ABORT_SCAN_TIME)
 from httpobs.scanner import STATE_ABORTED, STATE_FAILED, STATE_FINISHED, STATE_PENDING, STATE_STARTING
 from httpobs.scanner.analyzer import NUM_TESTS
-from httpobs.scanner.grader import get_grade_for_score
+from httpobs.scanner.grader import get_grade_and_likelihood_indicator_for_score
 
 import psycopg2
 import psycopg2.extras
@@ -140,15 +140,17 @@ def insert_test_results(site_id: int, scan_id: int, tests: list, response_header
                         (site_id, scan_id, name, expectation, result, passed, dumps(test), score_modifier))
 
         # Now we need to update the scans table
-        score, grade = get_grade_for_score(score)
+        score, grade, likelihood_indicator = get_grade_and_likelihood_indicator_for_score(score)
 
         # Update the scans table
         cur.execute("""UPDATE scans
-                         SET (end_time, tests_failed, tests_passed, grade, score, state, response_headers) =
+                         SET (end_time, tests_failed, tests_passed, grade, score, likelihood_indicator,
+                         state, response_headers) =
                          (NOW(), %s, %s, %s, %s, %s, %s)
                          WHERE id = %s
                          RETURNING *""",
-                    (tests_failed, tests_passed, grade, score, STATE_FINISHED, dumps(response_headers), scan_id))
+                    (tests_failed, tests_passed, grade, score, likelihood_indicator, STATE_FINISHED,
+                        dumps(response_headers), scan_id))
 
         row = dict(cur.fetchone())
 

--- a/httpobs/database/schema.sql
+++ b/httpobs/database/schema.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS scans (
   tests_quantity                      SMALLINT   NOT NULL,
   grade                               VARCHAR(2) NULL,
   score                               SMALLINT   NULL,
+  likelihood_indicator                VARCHAR(8) NULL,
   error                               VARCHAR    NULL,
   response_headers                    JSONB NULL,
   hidden                              BOOL       NOT NULL DEFAULT FALSE
@@ -105,3 +106,9 @@ ALTER MATERIALIZED VIEW grade_distribution OWNER TO httpobsscanner;  /* so it ca
 ALTER TABLE sites ADD COLUMN cookies JSONB NULL;
 GRANT UPDATE (cookies) ON sites TO httpobsapi;
  */
+
+/* Update to add likelihood indicator */
+/*
+ALTER TABLE scans ADD COLUMN likelihood_indicator VARCHAR(8) NULL;
+GRANT UPDATE (likelihood_indicator) on scans to httpobsapi;
+*/

--- a/httpobs/docs/api.md
+++ b/httpobs/docs/api.md
@@ -146,6 +146,7 @@ Example:
 * `response_headers` the entirety of the HTTP response headers
 * `scan_id` unique ID number assigned to the scan
 * `score` final score assessed upon a completed (`FINISHED`) scan
+* `likelihood_indicator` Mozilla risk likelihod indicator that is the equivalent of the grade [https://wiki.mozilla.org/Security/Standard_Levels] (https://wiki.mozilla.org/Security/Standard_Levels)
 * `start_time` timestamp for when the scan was first requested
 * `state` the current state of the scan
 * `tests_failed` the number of subtests that were assigned a fail result
@@ -168,6 +169,7 @@ Example:
   "response_headers": { ... },
   "scan_id": 1,
   "score": 90,
+  "likelihood_indicator": "LOW",
   "start_time": "Tue, 22 Mar 2016 21:51:40 GMT",
   "state": "FINISHED",
   "tests_failed": 2,

--- a/httpobs/scanner/grader/__init__.py
+++ b/httpobs/scanner/grader/__init__.py
@@ -1,7 +1,7 @@
-from .grade import get_score_description, get_score_modifier, get_grade_for_score, GRADES
+from .grade import get_score_description, get_score_modifier, get_grade_and_likelihood_indicator_for_score, GRADES
 
 
 __all__ = ['get_score_description',
            'get_score_modifier',
-           'get_grade_for_score',
+           'get_grade_and_likelihood_indicator_for_score',
            'GRADES']

--- a/httpobs/scanner/grader/grade.py
+++ b/httpobs/scanner/grader/grade.py
@@ -22,6 +22,25 @@ GRADE_CHART = {
     0: 'F'
 }
 
+# See https://wiki.mozilla.org/Security/Standard_Levels for a definition of the risk levels
+# We cannot make an accurate decision on HIGH and MAXIMUM risk likelihood indicators with the current checks,
+# thus the likelihood indicator is currently at best (or worse) MEDIUM
+LIKELIHOOD_INDICATOR_CHART = {
+    'A+': 'LOW',
+    'A': 'LOW',
+    'A-': 'LOW',
+    'B+': 'MEDIUM',
+    'B': 'MEDIUM',
+    'B-': 'MEDIUM',
+    'C+': 'MEDIUM',
+    'C': 'MEDIUM',
+    'C-': 'MEDIUM',
+    'D+': 'MEDIUM',
+    'D': 'MEDIUM',
+    'D-': 'MEDIUM',
+    'F': 'MEDIUM'
+}
+
 GRADES = set(GRADE_CHART.values())
 
 SCORE_TABLE = {
@@ -325,10 +344,10 @@ SCORE_TABLE = {
 }
 
 
-def get_grade_for_score(score: int) -> tuple:
+def get_grade_and_likelihood_indicator_for_score(score: int) -> tuple:
     """
     :param scan_id: the scan_id belonging to the tests to grade
-    :return: the overall test score and grade
+    :return: the overall test score, grade and likelihood_indicator
     """
 
     score = max(score, 0)  # can't have scores below 0
@@ -336,7 +355,11 @@ def get_grade_for_score(score: int) -> tuple:
     # If it's >100, just use the grade for 100, otherwise round down to the nearest multiple of 5
     grade = GRADE_CHART[min(score - score % 5, 100)]
 
-    return score, grade
+    # If GRADE_CHART and LIKELIHOOD_INDICATOR_CHART are not synchronized during
+    # manual code updates, then default to UNKNOWN
+    likelihood_indicator = LIKELIHOOD_INDICATOR_CHART.get(grade, 'UNKNOWN')
+
+    return score, grade, likelihood_indicator
 
 
 def get_score_description(result) -> str:


### PR DESCRIPTION
This stores the mapped likelihood indicator in the database and outputs it in the json message when retrieving a scan.

This means the likelihood indicator is static per scan (new scan required if the mapping OR scores change). This is akin to how
refreshing scores and grades (when the score table change) works.