### PR TITLE
Strengthen CSP test

### DIFF
--- a/httpobs/docs/scoring.md
+++ b/httpobs/docs/scoring.md
@@ -60,10 +60,10 @@ cross-origin-resource-sharing-<br>implemented-with-universal-access | Content is
 --- | --- | :---:
 csp-implemented-with-no-unsafe-default-src-none | Content Security Policy (CSP) implemented with `default-src 'none'` and without `'unsafe-inline'` or `'unsafe-eval'` | 10
 csp-implemented-with-no-unsafe | Content Security Policy (CSP) implemented without `'unsafe-inline'` or `'unsafe-eval'` | 5
-csp-implemented-with-unsafe-inline-in-style-src-only | Content Security Policy (CSP) implemented with `'unsafe-inline'` inside `style-src` | 0
+csp-implemented-with-unsafe-inline-in-style-src-only | Content Security Policy (CSP) implemented with unsafe directives inside `style-src`. This includes 'unsafe-inline', `data:`, or overly broad sources such as `https:`. | 0
 csp-implemented-with-unsafe-eval | Content Security Policy (CSP) implemented, but allows `'unsafe-eval'` | -10
-csp-implemented-with-insecure-scheme | Content Security Policy (CSP) implemented, but allows resources to be loaded from http | -20
-csp-implemented-with-unsafe-inline | Content Security Policy (CSP) implemented, but allows `'unsafe-inline'` inside `script-src` | -20
+csp-implemented-with-insecure-scheme | Content Security Policy (CSP) implemented, but secure site allows resources to be loaded from http | -20
+csp-implemented-with-unsafe-inline | Content Security Policy (CSP) implemented unsafely. This includes `\'unsafe-inline\'` or `data:` inside script-src, overly broad sources such as `https:` inside `object-src` or `script-src`, or not restricting the sources for `object-src` or `script-src`. | -20
 csp-not-implemented | Content Security Policy (CSP) header not implemented | -25
 csp-header-invalid | Content Security Policy (CSP) header cannot be parsed successfully | -25
 <br>

--- a/httpobs/scanner/grader/grade.py
+++ b/httpobs/scanner/grader/grade.py
@@ -57,7 +57,8 @@ SCORE_TABLE = {
         'modifier': 5,
     },
     'csp-implemented-with-unsafe-inline-in-style-src-only': {
-        'description': 'Content Security Policy (CSP) implemented with \'unsafe-inline\' inside style-src',
+        'description': ('Content Security Policy (CSP) implemented with unsafe sources inside style-src. '
+                        'This includes \'unsafe-inline\', data: or overly broad sources such as https:.'),
         'modifier': 0,
     },
     'csp-implemented-with-unsafe-eval': {
@@ -65,11 +66,15 @@ SCORE_TABLE = {
         'modifier': -10,
     },
     'csp-implemented-with-unsafe-inline': {
-        'description': 'Content Security Policy (CSP) implemented, but allows \'unsafe-inline\' inside script-src',
+        'description': ('Content Security Policy (CSP) implemented unsafely. '
+                        'This includes \'unsafe-inline\' or data: inside script-src, '
+                        'overly broad sources such as https: inside object-src or script-src, '
+                        'or not restricting the sources for object-src or script-src.'),
         'modifier': -20,
     },
     'csp-implemented-with-insecure-scheme': {
-        'description': 'Content Security Policy (CSP) implemented, but allows resources to be loaded from http',
+        'description': ('Content Security Policy (CSP) implemented, '
+                        'but secure site allows resources to be loaded from http'),
         'modifier': -20,
     },
     'csp-header-invalid': {


### PR DESCRIPTION
- Check for object-src not being set
- Check for overly broad sources such as https: or * in object-src,
script-src, and style-src
- Updated descriptions on things