### PR TITLE
Add support for mapping grades to Mozilla risk levels

### DIFF
--- a/httpobs/database/schema.sql
+++ b/httpobs/database/schema.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS scans (
   tests_quantity                      SMALLINT   NOT NULL,
   grade                               VARCHAR(2) NULL,
   score                               SMALLINT   NULL,
+  likelihood_indicator                VARCHAR    NULL,
   error                               VARCHAR    NULL,
   response_headers                    JSONB NULL,
   hidden                              BOOL       NOT NULL DEFAULT FALSE
@@ -105,3 +106,9 @@ ALTER MATERIALIZED VIEW grade_distribution OWNER TO httpobsscanner;  /* so it ca
 ALTER TABLE sites ADD COLUMN cookies JSONB NULL;
 GRANT UPDATE (cookies) ON sites TO httpobsapi;
  */
+
+/* Update to add likelihood indicator */
+/*
+ALTER TABLE scans ADD COLUMN likelihood_indicator VARCHAR NULL;
+GRANT UPDATE (likelihood_indicator) on scans to httpobsapi;
+*/

--- a/httpobs/docs/api.md
+++ b/httpobs/docs/api.md
@@ -146,6 +146,7 @@ Example:
 * `response_headers` the entirety of the HTTP response headers
 * `scan_id` unique ID number assigned to the scan
 * `score` final score assessed upon a completed (`FINISHED`) scan
+* `likelihood_indicator` Mozilla risk likelihod indicator that is the equivalent of the grade [https://wiki.mozilla.org/Security/Standard_Levels] (https://wiki.mozilla.org/Security/Standard_Levels)
 * `start_time` timestamp for when the scan was first requested
 * `state` the current state of the scan
 * `tests_failed` the number of subtests that were assigned a fail result
@@ -168,6 +169,7 @@ Example:
   "response_headers": { ... },
   "scan_id": 1,
   "score": 90,
+  "likelihood_indicator": "LOW",
   "start_time": "Tue, 22 Mar 2016 21:51:40 GMT",
   "state": "FINISHED",
   "tests_failed": 2,

--- a/httpobs/scanner/grader/__init__.py
+++ b/httpobs/scanner/grader/__init__.py
@@ -1,7 +1,7 @@
-from .grade import get_score_description, get_score_modifier, get_grade_for_score, GRADES
+from .grade import get_score_description, get_score_modifier, get_grade_and_likelihood_for_score, GRADES
 
 
 __all__ = ['get_score_description',
            'get_score_modifier',
-           'get_grade_for_score',
+           'get_grade_and_likelihood_for_score',
            'GRADES']

--- a/httpobs/scanner/grader/grade.py
+++ b/httpobs/scanner/grader/grade.py
@@ -22,6 +22,18 @@ GRADE_CHART = {
     0: 'F'
 }
 
+# See https://wiki.mozilla.org/Security/Standard_Levels for a definition of the risk levels
+# We cannot make an accurate decision on HIGH and MAXIMUM risk likelihood indicators with the current checks,
+# thus the likelihood indicator is currently at best (or worse) MEDIUM. Modifiers (A-A+B+B-, ... are normalized
+# A,B, ...) in the calling function.
+LIKELIHOOD_INDICATOR_CHART = {
+    'A': 'LOW',
+    'B': 'MEDIUM',
+    'C': 'MEDIUM',
+    'D': 'MEDIUM',
+    'F': 'MEDIUM'
+}
+
 GRADES = set(GRADE_CHART.values())
 
 SCORE_TABLE = {
@@ -330,10 +342,10 @@ SCORE_TABLE = {
 }
 
 
-def get_grade_for_score(score: int) -> tuple:
+def get_grade_and_likelihood_for_score(score: int) -> tuple:
     """
     :param scan_id: the scan_id belonging to the tests to grade
-    :return: the overall test score and grade
+    :return: the overall test score, grade and likelihood_indicator
     """
 
     score = max(score, 0)  # can't have scores below 0
@@ -341,7 +353,11 @@ def get_grade_for_score(score: int) -> tuple:
     # If it's >100, just use the grade for 100, otherwise round down to the nearest multiple of 5
     grade = GRADE_CHART[min(score - score % 5, 100)]
 
-    return score, grade
+    # If GRADE_CHART and LIKELIHOOD_INDICATOR_CHART are not synchronized during
+    # manual code updates, then default to UNKNOWN
+    likelihood_indicator = LIKELIHOOD_INDICATOR_CHART.get(grade[0], 'UNKNOWN')
+
+    return score, grade, likelihood_indicator
 
 
 def get_score_description(result) -> str:


### PR DESCRIPTION
Reuse and rename get_grade_for_score to get_grade_and_likelihood_indicator_for_score which now also returns a
likelihood_indictor - this is standardized and used to report risk at Mozilla.
This stores the mapped likelihood_indicator from this (http observatory) service in the database and outputs it in the json message when retrieving a scan.

This means the likelihood indicator is static per scan (new scan required if the mapping OR scores change). This is akin to how
refreshing scores and grades (when the score table change) works.

See also https://github.com/mozilla/http-observatory/pull/110
Github auto closed pull on my behalf when i rewrote the risk branch and can't re-open. Doh.
This includes fixes for all nits from pull 110.