### PR TITLE
Optionally support running against localhost

### DIFF
--- a/httpobs/conf/__init__.py
+++ b/httpobs/conf/__init__.py
@@ -86,3 +86,4 @@ SCANNER_MOZILLA_DOMAINS = [domain.strip() for domain in (environ.get('HTTPOBS_SC
                                                          __conf('scanner', 'mozilla_domains')).split(',')]
 SCANNER_PINNED_DOMAINS = [domain.strip() for domain in (environ.get('HTTPOBS_SCANNER_PINNED_DOMAINS') or
                                                         __conf('scanner', 'pinned_domains')).split(',')]
+SCANNER_ALLOW_LOCAL = environ.get('HTTPOBS_ALLOW_LOCAL') == 'yes' or __conf('scanner', 'allow_local', bool)

--- a/httpobs/conf/__init__.py
+++ b/httpobs/conf/__init__.py
@@ -71,6 +71,7 @@ RETRIEVER_CORS_ORIGIN = environ.get('HTTPOBS_RETRIEVER_CORS_ORIGIN') or __conf('
 # Scanner configuration
 SCANNER_ABORT_SCAN_TIME = int(environ.get('HTTPOBS_SCANNER_ABORT_SCAN_TIME') or
                               __conf('scanner', 'abort_scan_time'))
+SCANNER_ALLOW_LOCAL = environ.get('HTTPOBS_SCANNER_ALLOW_LOCAL') == 'yes' or __conf('scanner', 'allow_local', bool)
 SCANNER_BROKER_RECONNECTION_SLEEP_TIME = float(environ.get('HTTPOBS_SCANNER_BROKER_RECONNECTION_SLEEP_TIME') or
                                                __conf('scanner', 'broker_reconnection_sleep_time'))
 SCANNER_CYCLE_SLEEP_TIME = float(environ.get('HTTPOBS_SCANNER_CYCLE_SLEEP_TIME') or
@@ -86,4 +87,3 @@ SCANNER_MOZILLA_DOMAINS = [domain.strip() for domain in (environ.get('HTTPOBS_SC
                                                          __conf('scanner', 'mozilla_domains')).split(',')]
 SCANNER_PINNED_DOMAINS = [domain.strip() for domain in (environ.get('HTTPOBS_SCANNER_PINNED_DOMAINS') or
                                                         __conf('scanner', 'pinned_domains')).split(',')]
-SCANNER_ALLOW_LOCAL = environ.get('HTTPOBS_ALLOW_LOCAL') == 'yes' or __conf('scanner', 'allow_local', bool)

--- a/httpobs/conf/httpobs.conf
+++ b/httpobs/conf/httpobs.conf
@@ -24,6 +24,7 @@ user_agent = Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:48.0) Gecko/201001
 
 [scanner]
 abort_scan_time = 1800
+allow_local = no
 broker = redis://localhost:6379/0
 broker_reconnection_sleep_time = 15
 cycle_sleep_time = .5
@@ -32,4 +33,3 @@ maintenance_cycle_frequency = 900
 max_load_ratio_per_cpu = 3
 mozilla_domains = mozilla,allizom,browserid,firefox,persona,taskcluster,webmaker
 pinned_domains = accounts.firefox.com,addons.mozilla.org,aus4.mozilla.org,aus5.mozilla.org,cdn.mozilla.org,services.mozilla.com
-allow_local = no

--- a/httpobs/conf/httpobs.conf
+++ b/httpobs/conf/httpobs.conf
@@ -32,3 +32,4 @@ maintenance_cycle_frequency = 900
 max_load_ratio_per_cpu = 3
 mozilla_domains = mozilla,allizom,browserid,firefox,persona,taskcluster,webmaker
 pinned_domains = accounts.firefox.com,addons.mozilla.org,aus4.mozilla.org,aus5.mozilla.org,cdn.mozilla.org,services.mozilla.com
+allow_local = no

--- a/httpobs/scanner/analyzer/content.py
+++ b/httpobs/scanner/analyzer/content.py
@@ -44,6 +44,11 @@ def contribute(reqs: dict, expectation='contribute-json-with-required-keys') -> 
 
     response = reqs['responses']['auto']
 
+    # This finds the SLD ('mozilla' out of 'mozilla.org') if it exists
+    if '.' in urlparse(response.url).netloc:
+        second_level_domain = urlparse(response.url).netloc.split('.')[-2]
+    else:
+        second_level_domain = ""
     # If there's no contribute.json file
     if reqs['resources']['/contribute.json']:
         try:
@@ -67,7 +72,7 @@ def contribute(reqs: dict, expectation='contribute-json-with-required-keys') -> 
             else:
                 output['data'] = {}
 
-    elif urlparse(response.url).netloc.split('.')[-2] not in SCANNER_MOZILLA_DOMAINS:
+    elif second_level_domain not in SCANNER_MOZILLA_DOMAINS:
         output['expectation'] = output['result'] = 'contribute-json-only-required-on-mozilla-properties'
     else:
         output['result'] = 'contribute-json-not-implemented'

--- a/httpobs/scanner/analyzer/content.py
+++ b/httpobs/scanner/analyzer/content.py
@@ -48,7 +48,7 @@ def contribute(reqs: dict, expectation='contribute-json-with-required-keys') -> 
     if '.' in urlparse(response.url).netloc:
         second_level_domain = urlparse(response.url).netloc.split('.')[-2]
     else:
-        second_level_domain = ""
+        second_level_domain = ''
     # If there's no contribute.json file
     if reqs['resources']['/contribute.json']:
         try:

--- a/httpobs/scanner/utils.py
+++ b/httpobs/scanner/utils.py
@@ -1,5 +1,7 @@
 import socket
 
+from httpobs.conf import SCANNER_ALLOW_LOCAL
+
 
 def sanitize_headers(headers: dict) -> dict:
     """
@@ -23,7 +25,8 @@ def valid_hostname(hostname: str):
     """
 
     # Block attempts to scan things like 'localhost'
-    if '.' not in hostname or 'localhost' in hostname:
+    if (not SCANNER_ALLOW_LOCAL and
+        '.' not in hostname or 'localhost' in hostname):
         return False
 
     # First, let's try to see if it's an IPv4 address

--- a/httpobs/scanner/utils.py
+++ b/httpobs/scanner/utils.py
@@ -24,8 +24,8 @@ def valid_hostname(hostname: str):
     :return: Hostname if it's valid, otherwise False
     """
 
-    # Block attempts to scan things like 'localhost'
-    if not SCANNER_ALLOW_LOCAL and '.' not in hostname or 'localhost' in hostname:
+    # Block attempts to scan things like 'localhost' if not allowed
+    if ('.' not in hostname or 'localhost' in hostname) and not SCANNER_ALLOW_LOCAL:
         return False
 
     # First, let's try to see if it's an IPv4 address

--- a/httpobs/scanner/utils.py
+++ b/httpobs/scanner/utils.py
@@ -25,8 +25,7 @@ def valid_hostname(hostname: str):
     """
 
     # Block attempts to scan things like 'localhost'
-    if (not SCANNER_ALLOW_LOCAL and
-        '.' not in hostname or 'localhost' in hostname):
+    if not SCANNER_ALLOW_LOCAL and '.' not in hostname or 'localhost' in hostname:
         return False
 
     # First, let's try to see if it's an IPv4 address

--- a/httpobs/tests/unittests/test_valid_hostname.py
+++ b/httpobs/tests/unittests/test_valid_hostname.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from httpobs.scanner.utils import valid_hostname
 
@@ -17,3 +18,7 @@ class TestValidHostname(TestCase):
         self.assertFalse(valid_hostname('_spf.google.com'))  # no A records
         self.assertFalse(valid_hostname('127.0.0.1'))
         self.assertFalse(valid_hostname('2607:f8b0:4009:80b::200e'))
+
+    @patch('httpobs.scanner.utils.SCANNER_ALLOW_LOCAL', 'yes')
+    def test_valid_localhost(self):
+        self.assertTrue(valid_hostname('localhost'))


### PR DESCRIPTION
This adds the `SCANNER_ALLOW_LOCAL` option (controlled via
`scanner.allow_local` in `httpobs.conf` or `HTTPOBS_ALLOW_LOCAL`
environment variable). Allowing to scan localhost or any domain without
dots. Had to fix an implicit assumption on dots in the `contribute.json`
analyzer.

Fixes #65 and helps with #77