### PR TITLE
Add check for Referrer-Policy

### DIFF
--- a/httpobs/docs/scoring.md
+++ b/httpobs/docs/scoring.md
@@ -75,6 +75,7 @@ hpkp-implemented-<br>max-age-at-least-fifteen-days | HTTP Public Key Pinning (HP
 hpkp-implemented-<br>max-age-less-than-fifteen-days | HTTP Public Key Pinning (HPKP) header set to less than 15 days (1296000) | 1
 hpkp-header-invalid | HTTP Public Key Pinning (HPKP) header cannot be recognized | -5
 hpkp-not-implemented | HTTP Public Key Pinning (HPKP) header not implemented | 0
+hpkp-invalid-cert | HTTP Public Key Pinning (HPKP) header cannot be set, as site contains an invalid certificate chain | 0
 hpkp-not-implemented-no-https | HTTP Public Key Pinning (HPKP) header can't be implemented without https | 0
 <br>
 
@@ -85,6 +86,7 @@ hsts-implemented-<br>max-age-at-least-six-months | HTTP Strict Transport Securit
 hsts-implemented-<br>max-age-less-than-six-months | HTTP Strict Transport Security (HSTS) header set to less than six months (15768000) | -10
 hsts-not-implemented | HTTP Strict Transport Security (HSTS) header not implemented | -20
 hsts-not-implemented-no-https | HTTP Strict Transport Security (HSTS) header cannot be set for sites not available over https | -20
+hsts-invalid-cert | HTTP Strict Transport Security (HSTS) header cannot be set, as site contains an invalid certificate chain | -20
 hsts-header-invalid | HTTP Strict Transport Security (HSTS) header cannot be recognized | -20
 <br>
 
@@ -97,6 +99,7 @@ redirection-off-host-from-http | Initial redirection from http to https is to a 
 redirection-not-to-https-on-initial-redirection | Redirects to https eventually, but initial redirection is to another http URL | -10
 redirection-missing | Does not redirect to an https site | -20
 redirection-not-to-https | Redirects, but final destination is not an https URL | -20
+redirection-invalid-cert | Invalid certificate chain encountered during redirection | -20
 <br>
 
 [Subresource Integrity](https://wiki.mozilla.org/Security/Guidelines/Web_Security#Subresource_Integrity) | Description | Modifier
@@ -137,12 +140,17 @@ x-xss-protection-enabled | `X-XSS-Protection` header set to `1` | 0
 x-xss-protection-disabled | `X-XSS-Protection` header set to `0` (disabled) | -10
 x-xss-protection-not-implemented | `X-XSS-Protection` header not implemented | -10
 x-xss-protection-header-invalid | `X-XSS-Protection` header cannot be recognized | -10
-
 <br>
 
 [Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) | Description | Modifier
 --- | --- | :---:
-referrer-policy-header-enabled | `Referrer-Policy` header enabled | 5
+referrer-policy-header-no-referrer | `Referrer-Policy` header set to `no-referrer` | 5
+referrer-policy-header-no-referrer-when-downgrade | `Referrer-Policy` header set to `no-referrer-when-downgrade` | 5
+referrer-policy-header-origin | `Referrer-Policy` header set to `origin` | 5
+referrer-policy-header-origin-when-cross-origin | `Referrer-Policy` header set to `origin-when-cross-origin` | 5
+referrer-policy-header-same-origin | `Referrer-Policy` header set to `same-origin` | 5
+referrer-policy-header-strict-origin | `Referrer-Policy` header set to `strict-origin` | 5
+referrer-policy-header-strict-origin-when-cross-origin | `Referrer-Policy` header set to `strict-origin-when-cross-origin` | 5
 referrer-policy-header-not-implemented | `Referrer-Policy` header not implemented | 0
 referrer-policy-header-unsafe-url | `Referrer-Policy` header set to `unsafe-url` | -5
 referrer-policy-header-invalid | `Referrer-Policy` header cannot be recognized | -5

--- a/httpobs/docs/scoring.md
+++ b/httpobs/docs/scoring.md
@@ -3,7 +3,7 @@
 **Last Updated:** 2016-06-13 april@mozilla.com<br>
 **Author:** april@mozilla.com
 
-All websites start with a baseline score of 100, and then receive penalties or bonuses from there. Although the minimum score is 0, there is no maximum score. Currently, the highest possible score in the HTTP Observatory is 130.
+All websites start with a baseline score of 100, and then receive penalties or bonuses from there. Although the minimum score is 0, there is no maximum score. Currently, the highest possible score in the HTTP Observatory is 135.
 
 Note that although both the letter grade ranges and modifiers are essentially arbitrary, they are based on feedback from industry professionals on how important passing or failing a given test is likely to be.
 
@@ -137,3 +137,12 @@ x-xss-protection-enabled | `X-XSS-Protection` header set to `1` | 0
 x-xss-protection-disabled | `X-XSS-Protection` header set to `0` (disabled) | -10
 x-xss-protection-not-implemented | `X-XSS-Protection` header not implemented | -10
 x-xss-protection-header-invalid | `X-XSS-Protection` header cannot be recognized | -10
+
+<br>
+
+[Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) | Description | Modifier
+--- | --- | :---:
+referrer-policy-header-enabled | `Referrer-Policy` header enabled | 5
+referrer-policy-header-not-implemented | `Referrer-Policy` header not implemented | 0
+referrer-policy-header-unsafe-url | `Referrer-Policy` header set to `unsafe-url` | -5
+referrer-policy-header-invalid | `Referrer-Policy` header cannot be recognized | -5

--- a/httpobs/scanner/analyzer/__init__.py
+++ b/httpobs/scanner/analyzer/__init__.py
@@ -1,6 +1,6 @@
 from .content import contribute, subresource_integrity
 from .headers import (content_security_policy, cookies, public_key_pinning, strict_transport_security,
-                      x_content_type_options, x_xss_protection, x_frame_options)
+                      x_content_type_options, x_xss_protection, x_frame_options, http_referrer_policy)
 from .misc import cross_origin_resource_sharing, redirection
 
 __all__ = [
@@ -21,6 +21,7 @@ tests = (
     x_content_type_options,
     x_frame_options,
     x_xss_protection,
+    http_referrer_policy,
 )
 
 NUM_TESTS = len(tests)

--- a/httpobs/scanner/analyzer/__init__.py
+++ b/httpobs/scanner/analyzer/__init__.py
@@ -1,6 +1,6 @@
 from .content import contribute, subresource_integrity
-from .headers import (content_security_policy, cookies, public_key_pinning, strict_transport_security,
-                      x_content_type_options, x_xss_protection, x_frame_options, http_referrer_policy)
+from .headers import (content_security_policy, cookies, public_key_pinning, referrer_policy, strict_transport_security,
+                      x_content_type_options, x_xss_protection, x_frame_options)
 from .misc import cross_origin_resource_sharing, redirection
 
 __all__ = [
@@ -16,12 +16,12 @@ tests = (
     cross_origin_resource_sharing,
     public_key_pinning,
     redirection,
+    referrer_policy,
     strict_transport_security,
     subresource_integrity,
     x_content_type_options,
     x_frame_options,
     x_xss_protection,
-    http_referrer_policy,
 )
 
 NUM_TESTS = len(tests)

--- a/httpobs/scanner/analyzer/headers.py
+++ b/httpobs/scanner/analyzer/headers.py
@@ -542,3 +542,61 @@ def x_xss_protection(reqs: dict, expectation='x-xss-protection-1-mode-block') ->
             output['result'] = 'x-xss-protection-not-needed-due-to-csp'
 
     return output
+
+
+@scored_test
+def http_referrer_policy(reqs: dict, expectation='referrer-header-enabled') -> dict:
+    """
+    :param reqs: dictionary containing all the request and response objects
+    :param expectation: test expectation
+        referrer-policy-header-enabled: HTTP Referrer-Policy header enabled
+        referrer-policy-header-unsafe-url: HTTP Referrer-Policy header set to "unsafe-url"
+        referrer-policy-header-not-implemented: HTTP Referrer-Policy header not implemented
+        referrer-policy-header-invalid
+    :return: dictionary with:
+        data: the raw HTTP Referrer-Policy header
+        expectation: test expectation
+        pass: whether the site's configuration met its expectation
+        result: short string describing the result of the test
+    """
+
+    output = {
+        'data': None,
+        'expectation': expectation,
+        'pass': False,
+        'result': None,
+    }
+
+    values = ['no-referrer',
+              'no-referrer-when-downgrade',
+              'origin',
+              'origin-when-cross-origin',
+              'same-origin',
+              'strict-origin',
+              'strict-origin-when-cross-origin',
+              'unsafe-url']
+
+    response = reqs['responses']['auto']
+
+    if 'Referrer-Policy' in response.headers:
+        output['data'] = response.headers['Referrer-Policy']
+        policy = output['data'].lower().strip()
+
+        if policy in values and policy != 'unsafe-url':
+            output['result'] = 'referrer-policy-header-enabled'
+        elif policy == 'unsafe-url':
+            output['result'] = 'referrer-policy-header-unsafe-url'
+        else:
+            output['result'] = 'referrer-policy-header-invalid'
+    else:
+        output['result'] = 'referrer-policy-header-not-implemented'
+
+
+    # Test passed or failed
+    if output['result'] in ['referrer-policy-header-enabled',
+                            'referrer-policy-header-not-implemented',
+                            expectation]:
+        output['pass'] = True
+
+    return output
+

--- a/httpobs/scanner/analyzer/misc.py
+++ b/httpobs/scanner/analyzer/misc.py
@@ -50,6 +50,7 @@ def cross_origin_resource_sharing(reqs: dict, expectation='cross-origin-resource
         'result': 'cross-origin-resource-sharing-not-implemented',
     }
 
+    # TODO: Fix ACAO being null?
     acao = reqs['responses']['cors']
 
     if acao is not None:
@@ -107,6 +108,7 @@ def redirection(reqs: dict, expectation='redirection-to-https') -> dict:
         redirection-missing: No redirection takes place, staying on HTTP
         redirection-not-needed-no-http: Site doesn't listen for HTTP requests at all
         redirection-off-host-from-http: Initial HTTP allowed to go from one host to another, still redirects to HTTPS
+        redirection-invalid-cert: Invalid certificate chain encountered
     :return: dictionary with:
         destination: final location of where GET / over HTTP ends
         expectation: test expectation
@@ -130,6 +132,11 @@ def redirection(reqs: dict, expectation='redirection-to-https') -> dict:
 
     if response is None:
         output['result'] = 'redirection-not-needed-no-http'
+
+    # If we encountered an invalid certificate during the redirection process, that's a no-go
+    elif not response.verified:
+        output['result'] = 'redirection-invalid-cert'
+
     else:
         # Construct the route
         output['route'] = [r.request.url for r in response.history] if response.history else []

--- a/httpobs/scanner/grader/grade.py
+++ b/httpobs/scanner/grader/grade.py
@@ -169,6 +169,11 @@ SCORE_TABLE = {
         'description': 'HTTP Public Key Pinning (HPKP) header can\'t be implemented without https',
         'modifier': 0,
     },
+    'hpkp-invalid-cert': {
+        'description': ('HTTP Public Key Pinning (HPKP) header cannot be set, '
+                        'as site contains an invalid certificate chain'),
+        'modifier': 0,
+    },
     'hpkp-header-invalid': {
         'description': 'HTTP Public Key Pinning (HPKP) header cannot be recognized',
         'modifier': -5,
@@ -200,7 +205,11 @@ SCORE_TABLE = {
         'modifier': -20,
     },
     'redirection-missing': {
-        'description': 'Does not redirect to an https site',  # if there's no HTTPS at all, other tests will score -100
+        'description': 'Does not redirect to an https site',
+        'modifier': -20,
+    },
+    'redirection-invalid-cert': {
+        'description': 'Invalid certificate chain encountered during redirection',
         'modifier': -20,
     },
 
@@ -227,6 +236,11 @@ SCORE_TABLE = {
     },
     'hsts-not-implemented-no-https': {
         'description': 'HTTP Strict Transport Security (HSTS) header cannot be set for sites not available over https',
+        'modifier': -20,
+    },
+    'hsts-invalid-cert': {
+        'description': ('HTTP Strict Transport Security (HSTS) header cannot be set, '
+                        'as site contains an invalid certificate chain'),
         'modifier': -20,
     },
 
@@ -327,20 +341,44 @@ SCORE_TABLE = {
     },
 
     # HTTP Referrer Policy
-    'referrer-policy-header-enabled': {
-        'description': 'HTTP Referrer-Policy header enabled',
-        'modifier': +5,
+    'referrer-policy-header-no-referrer': {
+        'description': 'HTTP Referrer Policy set to "no-referrer"',
+        'modifier': 5,
+    },
+    'referrer-policy-header-no-referrer-when-downgrade': {
+        'description': 'HTTP Referrer Policy set to "no-referrer-when-downgrade"',
+        'modifier': 5,
+    },
+    'referrer-policy-header-origin': {
+        'description': 'HTTP Referrer Policy set to "origin"',
+        'modifier': 5,
+    },
+    'referrer-policy-header-origin-when-cross-origin': {
+        'description': 'HTTP Referrer Policy set to "origin-when-cross-origin"',
+        'modifier': 5,
+    },
+    'referrer-policy-header-same-origin': {
+        'description': 'HTTP Referrer Policy set to "same-origin"',
+        'modifier': 5,
+    },
+    'referrer-policy-header-strict-origin': {
+        'description': 'HTTP Referrer Policy set to "strict-origin"',
+        'modifier': 5,
+    },
+    'referrer-policy-header-strict-origin-when-cross-origin': {
+        'description': 'HTTP Referrer Policy set to "strict-origin-when-cross-origin"',
+        'modifier': 5,
     },
     'referrer-policy-header-not-implemented': {
-        'description': 'HTTP Referrer-Policy header not implemented',
+        'description': 'HTTP Referrer Policy not implemented',
         'modifier': 0,
     },
     'referrer-policy-header-unsafe-url': {
-        'description': 'HTTP Referrer-Policy header set to "unsafe-url"',
+        'description': 'HTTP Referrer Policy set to "unsafe-url"',
         'modifier': -5,
     },
     'referrer-policy-header-invalid': {
-        'description': 'HTTP Referrer-Policy header cannot be recognized',
+        'description': 'HTTP Referrer Policy cannot be recognized',
         'modifier': -5,
     },
 
@@ -357,7 +395,6 @@ SCORE_TABLE = {
         'description': 'Claims to be xml, but cannot be parsed',
         'modifier': -20,  # can't run an ACAO check if the xml files can't be parsed
     }
-
 }
 
 

--- a/httpobs/scanner/grader/grade.py
+++ b/httpobs/scanner/grader/grade.py
@@ -326,6 +326,24 @@ SCORE_TABLE = {
         'modifier': -10,
     },
 
+    # HTTP Referrer Policy
+    'referrer-policy-header-enabled': {
+        'description': 'HTTP Referrer-Policy header enabled',
+        'modifier': +5,
+    },
+    'referrer-policy-header-not-implemented': {
+        'description': 'HTTP Referrer-Policy header not implemented',
+        'modifier': 0,
+    },
+    'referrer-policy-header-unsafe-url': {
+        'description': 'HTTP Referrer-Policy header set to "unsafe-url"',
+        'modifier': -5,
+    },
+    'referrer-policy-header-invalid': {
+        'description': 'HTTP Referrer-Policy header cannot be recognized',
+        'modifier': -5,
+    },
+
     # Generic results
     'html-not-parsable': {
         'description': 'Claims to be html, but cannot be parsed',
@@ -339,6 +357,7 @@ SCORE_TABLE = {
         'description': 'Claims to be xml, but cannot be parsed',
         'modifier': -20,  # can't run an ACAO check if the xml files can't be parsed
     }
+
 }
 
 

--- a/httpobs/tests/unittests/test_misc.py
+++ b/httpobs/tests/unittests/test_misc.py
@@ -167,6 +167,21 @@ class TestRedirection(TestCase):
                            'https://http-observatory.security.mozilla.org/'], result['route'])
         self.assertTrue(result['pass'])
 
+    def test_redirects_invalid_cert(self):
+        history1 = UserDict()
+        history1.request = UserDict()
+        history1.request.url = 'http://http-observatory.security.mozilla.org/'
+
+        self.reqs['responses']['http'].history.append(history1)
+
+        # Mark it as verification failed
+        self.reqs['responses']['http'].verified = False
+
+        result = redirection(self.reqs)
+
+        self.assertEquals('redirection-invalid-cert', result['result'])
+        self.assertFalse(result['pass'])
+
     def test_first_redirection_still_http(self):
         self.reqs['responses']['http'].url = 'https://http-observatory.security.mozilla.org/foo'
 

--- a/httpobs/tests/unittests/test_retriever.py
+++ b/httpobs/tests/unittests/test_retriever.py
@@ -43,3 +43,8 @@ class TestRetriever(TestCase):
         self.assertEquals(2, len(reqs['responses']['auto'].history))
         self.assertEquals(200, reqs['responses']['auto'].status_code)
         self.assertEquals('https://www.mozilla.org/en-US/', reqs['responses']['auto'].url)
+
+    def test_retrieve_invalid_cert(self):
+        reqs = retrieve_all('expired.badssl.com')
+
+        self.assertFalse(reqs['responses']['auto'].verified)

--- a/httpobs/tests/utils.py
+++ b/httpobs/tests/utils.py
@@ -30,6 +30,7 @@ def empty_requests() -> dict:
     req['responses']['auto'].request.headers = UserDict()
     req['responses']['auto'].status_code = 200
     req['responses']['auto'].url = 'https://http-observatory.security.mozilla.org/'
+    req['responses']['auto'].verified = True
 
     req['session'].cookies = CookieJar()
 


### PR DESCRIPTION
Hi,
I added a check for the HTTP Referrer-Policy header (as discussed in #107)
I applied the following (basic) score:

1. +5 if the Referrer-Policy is set with a value different from **_unsafe-url_**
2. 0 if the Referrer-Policy is not implemented
3. -5 if the Referrer-Policy is set with **_unsafe-url_**
4. -5 if the Referrer-Policy is set with an unknown value

