### PR TITLE
Added support for Referrer Policy Header

### DIFF
--- a/httpobs/docs/scoring.md
+++ b/httpobs/docs/scoring.md
@@ -3,7 +3,7 @@
 **Last Updated:** 2016-06-13 april@mozilla.com<br>
 **Author:** april@mozilla.com
 
-All websites start with a baseline score of 100, and then receive penalties or bonuses from there. Although the minimum score is 0, there is no maximum score. Currently, the highest possible score in the HTTP Observatory is 130.
+All websites start with a baseline score of 100, and then receive penalties or bonuses from there. Although the minimum score is 0, there is no maximum score. Currently, the highest possible score in the HTTP Observatory is 135.
 
 Note that although both the letter grade ranges and modifiers are essentially arbitrary, they are based on feedback from industry professionals on how important passing or failing a given test is likely to be.
 
@@ -140,3 +140,14 @@ x-xss-protection-enabled | `X-XSS-Protection` header set to `1` | 0
 x-xss-protection-disabled | `X-XSS-Protection` header set to `0` (disabled) | -10
 x-xss-protection-not-implemented | `X-XSS-Protection` header not implemented | -10
 x-xss-protection-header-invalid | `X-XSS-Protection` header cannot be recognized | -10
+<br>
+
+[Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) | Description | Modifier
+--- | --- | :---:
+referrer-policy-private | `Referrer-Policy` header set to `no-referrer` or `same-origin`, `strict-origin` or `strict-origin-when-cross-origin` | 5
+referrer-policy-no-referrer-when-downgrade | `Referrer-Policy` header set to `no-referrer-when-downgrade` | 0
+referrer-policy-not-implemented | `Referrer-Policy` header not implemented | 0
+referrer-policy-origin | `Referrer-Policy` header set to `origin` | -5
+referrer-policy-origin-when-cross-origin | `Referrer-Policy` header set to `origin-when-cross-origin` | -5
+referrer-policy-unsafe-url | `Referrer-Policy` header set to `unsafe-url` | -5
+referrer-policy-invalid | `Referrer-Policy` header cannot be recognized | -5

--- a/httpobs/docs/scoring.md
+++ b/httpobs/docs/scoring.md
@@ -102,6 +102,17 @@ redirection-not-to-https | Redirects, but final destination is not an https URL 
 redirection-invalid-cert | Invalid certificate chain encountered during redirection | -20
 <br>
 
+[Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) | Description | Modifier
+--- | --- | :---:
+referrer-policy-private | `Referrer-Policy` header set to `no-referrer` or `same-origin`, `strict-origin` or `strict-origin-when-cross-origin` | 5
+referrer-policy-no-referrer-when-downgrade | `Referrer-Policy` header set to `no-referrer-when-downgrade` | 0
+referrer-policy-not-implemented | `Referrer-Policy` header not implemented | 0
+referrer-policy-origin | `Referrer-Policy` header set to `origin` | -5
+referrer-policy-origin-when-cross-origin | `Referrer-Policy` header set to `origin-when-cross-origin` | -5
+referrer-policy-unsafe-url | `Referrer-Policy` header set to `unsafe-url` | -5
+referrer-policy-header-invalid | `Referrer-Policy` header cannot be recognized | -5
+<br>
+
 [Subresource Integrity](https://wiki.mozilla.org/Security/Guidelines/Web_Security#Subresource_Integrity) | Description | Modifier
 --- | --- | :---:
 sri-implemented-<br>and-all-scripts-loaded-securely | Subresource Integrity (SRI) is implemented and all scripts are loaded from a similar origin | 5
@@ -140,14 +151,3 @@ x-xss-protection-enabled | `X-XSS-Protection` header set to `1` | 0
 x-xss-protection-disabled | `X-XSS-Protection` header set to `0` (disabled) | -10
 x-xss-protection-not-implemented | `X-XSS-Protection` header not implemented | -10
 x-xss-protection-header-invalid | `X-XSS-Protection` header cannot be recognized | -10
-<br>
-
-[Referrer-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) | Description | Modifier
---- | --- | :---:
-referrer-policy-private | `Referrer-Policy` header set to `no-referrer` or `same-origin`, `strict-origin` or `strict-origin-when-cross-origin` | 5
-referrer-policy-no-referrer-when-downgrade | `Referrer-Policy` header set to `no-referrer-when-downgrade` | 0
-referrer-policy-not-implemented | `Referrer-Policy` header not implemented | 0
-referrer-policy-origin | `Referrer-Policy` header set to `origin` | -5
-referrer-policy-origin-when-cross-origin | `Referrer-Policy` header set to `origin-when-cross-origin` | -5
-referrer-policy-unsafe-url | `Referrer-Policy` header set to `unsafe-url` | -5
-referrer-policy-invalid | `Referrer-Policy` header cannot be recognized | -5

--- a/httpobs/scanner/analyzer/__init__.py
+++ b/httpobs/scanner/analyzer/__init__.py
@@ -1,5 +1,5 @@
 from .content import contribute, subresource_integrity
-from .headers import (content_security_policy, cookies, public_key_pinning, strict_transport_security,
+from .headers import (content_security_policy, cookies, public_key_pinning, referrer_policy, strict_transport_security,
                       x_content_type_options, x_xss_protection, x_frame_options)
 from .misc import cross_origin_resource_sharing, redirection
 
@@ -16,6 +16,7 @@ tests = (
     cross_origin_resource_sharing,
     public_key_pinning,
     redirection,
+    referrer_policy,
     strict_transport_security,
     subresource_integrity,
     x_content_type_options,

--- a/httpobs/scanner/analyzer/headers.py
+++ b/httpobs/scanner/analyzer/headers.py
@@ -552,3 +552,66 @@ def x_xss_protection(reqs: dict, expectation='x-xss-protection-1-mode-block') ->
             output['result'] = 'x-xss-protection-not-needed-due-to-csp'
 
     return output
+
+
+@scored_test
+def referrer_policy(reqs: dict, expectation='referrer-policy-private') -> dict:
+    """
+    :param reqs: dictionary containing all the request and response objects
+    :param expectation: test expectation
+        referrer-policy-private: HTTP Referrer Policy set to "no-referrer" or "same-origin", "strict-origin"
+          or "strict-origin-when-origin"
+        referrer-policy-no-referrer-when-downgrade: HTTP Referrer Policy set to "no-referrer-when-downgrade"
+        referrer-policy-origin: HTTP Referrer Policy set to "origin"
+        referrer-policy-origin-when-cross-origin: HTTP Referrer Policy set to "origin-when-cross-origin"
+        referrer-policy-unsafe-url: HTTP Referrer Policy header set to "unsafe-url"
+        referrer-policy-not-implemented: HTTP Referrer Policy header not implemented
+        referrer-policy-invalid
+    :return: dictionary with:
+        data: the raw HTTP Referrer-Policy header
+        expectation: test expectation
+        pass: whether the site's configuration met its expectation
+        result: short string describing the result of the test
+    """
+
+    output = {
+        'data': None,
+        'expectation': expectation,
+        'pass': False,
+        'result': None,
+    }
+
+    goodness = ['no-referrer',
+                'same-origin',
+                'strict-origin',
+                'strict-origin-when-cross-origin']
+
+    badness = {'origin': 'referrer-policy-origin',
+               'origin-when-cross-origin': 'referrer-policy-origin-when-cross-origin',
+               'unsafe-url': 'referrer-policy-unsafe-url'}
+
+    response = reqs['responses']['auto']
+
+    if 'Referrer-Policy' in response.headers:
+        output['data'] = response.headers['Referrer-Policy'][0:256]  # Code defensively
+        policy = output['data'].lower().strip()
+
+        if policy in goodness:
+            output['result'] = 'referrer-policy-private'
+        elif policy == 'no-referrer-when-downgrade':
+            output['result'] = 'referrer-policy-no-referrer-when-downgrade'
+        elif policy in badness.keys():
+            output['result'] = badness[policy]
+        else:
+            output['result'] = 'referrer-policy-invalid'
+    else:
+        output['result'] = 'referrer-policy-not-implemented'
+
+    # Test passed or failed
+    if output['result'] in ('referrer-policy-private',
+                            'referrer-policy-not-implemented',
+                            'referrer-policy-no-referrer-when-downgrade',
+                            expectation):
+        output['pass'] = True
+
+    return output

--- a/httpobs/scanner/analyzer/headers.py
+++ b/httpobs/scanner/analyzer/headers.py
@@ -304,6 +304,71 @@ def public_key_pinning(reqs: dict, expectation='hpkp-not-implemented') -> dict:
 
 
 @scored_test
+def referrer_policy(reqs: dict, expectation='referrer-policy-private') -> dict:
+    """
+    :param reqs: dictionary containing all the request and response objects
+    :param expectation: test expectation
+        referrer-policy-private: Referrer-Policy header set to "no-referrer" or "same-origin", "strict-origin"
+          or "strict-origin-when-origin"
+        referrer-policy-no-referrer-when-downgrade: Referrer-Policy header set to "no-referrer-when-downgrade"
+        referrer-policy-origin: Referrer-Policy header set to "origin"
+        referrer-policy-origin-when-cross-origin: Referrer-Policy header set to "origin-when-cross-origin"
+        referrer-policy-unsafe-url: Referrer-Policy header set to "unsafe-url"
+        referrer-policy-not-implemented: Referrer-Policy header not implemented
+        referrer-policy-header-invalid
+    :return: dictionary with:
+        data: the raw HTTP Referrer-Policy header
+        expectation: test expectation
+        pass: whether the site's configuration met its expectation
+        result: short string describing the result of the test
+    """
+
+    output = {
+        'data': None,
+        'expectation': expectation,
+        'pass': False,
+        'result': None,
+    }
+
+    goodness = ['no-referrer',
+                'same-origin',
+                'strict-origin',
+                'strict-origin-when-cross-origin']
+
+    badness = {'origin': 'referrer-policy-origin',
+               'origin-when-cross-origin': 'referrer-policy-origin-when-cross-origin',
+               'unsafe-url': 'referrer-policy-unsafe-url'}
+
+    response = reqs['responses']['auto']
+
+    if 'Referrer-Policy' in response.headers:
+        output['data'] = response.headers['Referrer-Policy'][0:256]  # Code defensively
+        policy_tokens = list(map(str.strip, response.headers['Referrer-Policy'].lower().split(',')))
+        policy = next((token for token in policy_tokens[::-1] if token in goodness + list(badness) +
+                       ['no-referrer-when-downgrade']), None)
+
+        if policy in goodness:
+            output['result'] = 'referrer-policy-private'
+        elif policy == 'no-referrer-when-downgrade':
+            output['result'] = 'referrer-policy-no-referrer-when-downgrade'
+        elif policy in list(badness):
+            output['result'] = badness[policy]
+        else:
+            output['result'] = 'referrer-policy-header-invalid'
+    else:
+        output['result'] = 'referrer-policy-not-implemented'
+
+    # Test passed or failed
+    if output['result'] in ('referrer-policy-private',
+                            'referrer-policy-not-implemented',
+                            'referrer-policy-no-referrer-when-downgrade',
+                            expectation):
+        output['pass'] = True
+
+    return output
+
+
+@scored_test
 def strict_transport_security(reqs: dict, expectation='hsts-implemented-max-age-at-least-six-months') -> dict:
     """
     :param reqs: dictionary containing all the request and response objects
@@ -550,68 +615,5 @@ def x_xss_protection(reqs: dict, expectation='x-xss-protection-1-mode-block') ->
         if content_security_policy(reqs)['pass']:
             output['pass'] = True
             output['result'] = 'x-xss-protection-not-needed-due-to-csp'
-
-    return output
-
-
-@scored_test
-def referrer_policy(reqs: dict, expectation='referrer-policy-private') -> dict:
-    """
-    :param reqs: dictionary containing all the request and response objects
-    :param expectation: test expectation
-        referrer-policy-private: HTTP Referrer Policy set to "no-referrer" or "same-origin", "strict-origin"
-          or "strict-origin-when-origin"
-        referrer-policy-no-referrer-when-downgrade: HTTP Referrer Policy set to "no-referrer-when-downgrade"
-        referrer-policy-origin: HTTP Referrer Policy set to "origin"
-        referrer-policy-origin-when-cross-origin: HTTP Referrer Policy set to "origin-when-cross-origin"
-        referrer-policy-unsafe-url: HTTP Referrer Policy header set to "unsafe-url"
-        referrer-policy-not-implemented: HTTP Referrer Policy header not implemented
-        referrer-policy-invalid
-    :return: dictionary with:
-        data: the raw HTTP Referrer-Policy header
-        expectation: test expectation
-        pass: whether the site's configuration met its expectation
-        result: short string describing the result of the test
-    """
-
-    output = {
-        'data': None,
-        'expectation': expectation,
-        'pass': False,
-        'result': None,
-    }
-
-    goodness = ['no-referrer',
-                'same-origin',
-                'strict-origin',
-                'strict-origin-when-cross-origin']
-
-    badness = {'origin': 'referrer-policy-origin',
-               'origin-when-cross-origin': 'referrer-policy-origin-when-cross-origin',
-               'unsafe-url': 'referrer-policy-unsafe-url'}
-
-    response = reqs['responses']['auto']
-
-    if 'Referrer-Policy' in response.headers:
-        output['data'] = response.headers['Referrer-Policy'][0:256]  # Code defensively
-        policy = output['data'].lower().strip()
-
-        if policy in goodness:
-            output['result'] = 'referrer-policy-private'
-        elif policy == 'no-referrer-when-downgrade':
-            output['result'] = 'referrer-policy-no-referrer-when-downgrade'
-        elif policy in badness.keys():
-            output['result'] = badness[policy]
-        else:
-            output['result'] = 'referrer-policy-invalid'
-    else:
-        output['result'] = 'referrer-policy-not-implemented'
-
-    # Test passed or failed
-    if output['result'] in ('referrer-policy-private',
-                            'referrer-policy-not-implemented',
-                            'referrer-policy-no-referrer-when-downgrade',
-                            expectation):
-        output['pass'] = True
 
     return output

--- a/httpobs/scanner/grader/grade.py
+++ b/httpobs/scanner/grader/grade.py
@@ -340,6 +340,37 @@ SCORE_TABLE = {
         'modifier': -10,
     },
 
+    # Referrer Policy
+    'referrer-policy-private': {
+        'description': ('HTTP Referrer Policy set to "no-referrer" or "same-origin", "strict-origin" or ',
+                        '"strict-origin-when-cross-origin"'),
+        'modifier': 5,
+    },
+    'referrer-policy-no-referrer-when-downgrade': {
+        'description': 'HTTP Referrer Policy set to "no-referrer-when-downgrade"',
+        'modifier': 0,
+    },
+    'referrer-policy-not-implemented': {
+        'description': 'HTTP Referrer Policy not implemented',
+        'modifier': 0,
+    },
+    'referrer-policy-origin': {
+        'description': 'HTTP Referrer Policy set to "origin"',
+        'modifier': -5,
+    },
+    'referrer-policy-origin-when-cross-origin': {
+        'description': 'HTTP Referrer Policy set to "origin-when-cross-origin"',
+        'modifier': -5,
+    },
+    'referrer-policy-unsafe-url': {
+        'description': 'HTTP Referrer Policy set to "unsafe-url"',
+        'modifier': -5,
+    },
+    'referrer-policy-invalid': {
+        'description': 'HTTP Referrer Policy cannot be recognized',
+        'modifier': -5,
+    },
+
     # Generic results
     'html-not-parsable': {
         'description': 'Claims to be html, but cannot be parsed',

--- a/httpobs/scanner/grader/grade.py
+++ b/httpobs/scanner/grader/grade.py
@@ -213,6 +213,37 @@ SCORE_TABLE = {
         'modifier': -20,
     },
 
+    # Referrer Policy
+    'referrer-policy-private': {
+        'description': ('Referrer-Policy header set to "no-referrer" or "same-origin", "strict-origin" or ',
+                        '"strict-origin-when-cross-origin"'),
+        'modifier': 5,
+    },
+    'referrer-policy-no-referrer-when-downgrade': {
+        'description': 'Referrer-Policy header set to "no-referrer-when-downgrade"',
+        'modifier': 0,
+    },
+    'referrer-policy-not-implemented': {
+        'description': 'Referrer-Policy header not implemented',
+        'modifier': 0,
+    },
+    'referrer-policy-origin': {
+        'description': 'Referrer-Policy header set to "origin"',
+        'modifier': -5,
+    },
+    'referrer-policy-origin-when-cross-origin': {
+        'description': 'Referrer-Policy header set to "origin-when-cross-origin"',
+        'modifier': -5,
+    },
+    'referrer-policy-unsafe-url': {
+        'description': 'Referrer-Policy header set to "unsafe-url"',
+        'modifier': -5,
+    },
+    'referrer-policy-header-invalid': {
+        'description': 'Referrer-Policy header cannot be recognized',
+        'modifier': -5,
+    },
+
     # Strict Transport Security (HSTS)
     'hsts-preloaded': {
         'description': 'Preloaded via the HTTP Strict Transport Security (HSTS) preloading process',
@@ -338,37 +369,6 @@ SCORE_TABLE = {
     'x-xss-protection-header-invalid': {
         'description': 'X-XSS-Protection header cannot be recognized',
         'modifier': -10,
-    },
-
-    # Referrer Policy
-    'referrer-policy-private': {
-        'description': ('HTTP Referrer Policy set to "no-referrer" or "same-origin", "strict-origin" or ',
-                        '"strict-origin-when-cross-origin"'),
-        'modifier': 5,
-    },
-    'referrer-policy-no-referrer-when-downgrade': {
-        'description': 'HTTP Referrer Policy set to "no-referrer-when-downgrade"',
-        'modifier': 0,
-    },
-    'referrer-policy-not-implemented': {
-        'description': 'HTTP Referrer Policy not implemented',
-        'modifier': 0,
-    },
-    'referrer-policy-origin': {
-        'description': 'HTTP Referrer Policy set to "origin"',
-        'modifier': -5,
-    },
-    'referrer-policy-origin-when-cross-origin': {
-        'description': 'HTTP Referrer Policy set to "origin-when-cross-origin"',
-        'modifier': -5,
-    },
-    'referrer-policy-unsafe-url': {
-        'description': 'HTTP Referrer Policy set to "unsafe-url"',
-        'modifier': -5,
-    },
-    'referrer-policy-invalid': {
-        'description': 'HTTP Referrer Policy cannot be recognized',
-        'modifier': -5,
     },
 
     # Generic results

--- a/httpobs/tests/unittests/test_headers.py
+++ b/httpobs/tests/unittests/test_headers.py
@@ -469,6 +469,93 @@ class TestPublicKeyPinning(TestCase):
         self.assertTrue(result['preloaded'])
 
 
+class TestReferrerPolicy(TestCase):
+    def setUp(self):
+        self.reqs = empty_requests()
+
+    def tearDown(self):
+        self.reqs = None
+
+    def test_header_private(self):
+        for policy in ['no-referrer', 'same-origin', 'strict-origin', 'strict-origin-when-cross-origin']:
+            self.reqs['responses']['auto'].headers['Referrer-Policy'] = policy
+
+            result = referrer_policy(self.reqs)
+
+            self.assertEquals('referrer-policy-private', result['result'])
+            self.assertTrue(result['pass'])
+
+    def test_header_no_referrer_when_downgrade(self):
+        self.reqs['responses']['auto'].headers['Referrer-Policy'] = 'no-referrer-when-downgrade'
+
+        result = referrer_policy(self.reqs)
+
+        self.assertEquals('referrer-policy-no-referrer-when-downgrade', result['result'])
+        self.assertTrue(result['pass'])
+
+    def test_missing(self):
+        result = referrer_policy(self.reqs)
+
+        self.assertEquals('referrer-policy-not-implemented', result['result'])
+        self.assertTrue(result['pass'])
+
+    def test_header_invalid(self):
+        self.reqs['responses']['auto'].headers['Referrer-Policy'] = 'whimsy'
+
+        result = referrer_policy(self.reqs)
+
+        self.assertEquals('referrer-policy-header-invalid', result['result'])
+        self.assertFalse(result['pass'])
+
+    def test_header_unsafe_url(self):
+        self.reqs['responses']['auto'].headers['Referrer-Policy'] = 'unsafe-url'
+
+        result = referrer_policy(self.reqs)
+
+        self.assertEquals('referrer-policy-unsafe-url', result['result'])
+        self.assertFalse(result['pass'])
+
+    def test_header_origin(self):
+        self.reqs['responses']['auto'].headers['Referrer-Policy'] = 'origin'
+
+        result = referrer_policy(self.reqs)
+
+        self.assertEquals('referrer-policy-origin', result['result'])
+        self.assertFalse(result['pass'])
+
+    def test_header_origin_when_cross_origin(self):
+        self.reqs['responses']['auto'].headers['Referrer-Policy'] = 'origin-when-cross-origin'
+
+        result = referrer_policy(self.reqs)
+
+        self.assertEquals('referrer-policy-origin-when-cross-origin', result['result'])
+        self.assertFalse(result['pass'])
+
+    def test_multiple_value_header_all_valid(self):
+        self.reqs['responses']['auto'].headers['Referrer-Policy'] = 'origin-when-cross-origin, no-referrer, unsafe-url'
+
+        result = referrer_policy(self.reqs)
+
+        self.assertEquals('referrer-policy-unsafe-url', result['result'])
+        self.assertFalse(result['pass'])
+
+    def test_multiple_value_header_mix(self):
+        self.reqs['responses']['auto'].headers['Referrer-Policy'] = 'no-referrer, whimsy'
+
+        result = referrer_policy(self.reqs)
+
+        self.assertEquals('referrer-policy-private', result['result'])
+        self.assertTrue(result['pass'])
+
+    def test_multiple_value_header_invalid(self):
+        self.reqs['responses']['auto'].headers['Referrer-Policy'] = 'whimsy, whimsy1, whimsy2'
+
+        result = referrer_policy(self.reqs)
+
+        self.assertEquals('referrer-policy-header-invalid', result['result'])
+        self.assertFalse(result['pass'])
+
+
 class TestStrictTransportSecurity(TestCase):
     def setUp(self):
         self.reqs = empty_requests()
@@ -707,66 +794,3 @@ class TestXXSSProtection(TestCase):
 
         self.assertEquals('x-xss-protection-not-needed-due-to-csp', result['result'])
         self.assertTrue(result['pass'])
-
-
-class TestReferrerPolicy(TestCase):
-    def setUp(self):
-        self.reqs = empty_requests()
-
-    def tearDown(self):
-        self.reqs = None
-
-    def test_header_private(self):
-        for policy in ['no-referrer', 'same-origin', 'strict-origin', 'strict-origin-when-cross-origin']:
-            self.reqs['responses']['auto'].headers['Referrer-Policy'] = policy
-
-            result = referrer_policy(self.reqs)
-
-            self.assertEquals('referrer-policy-private', result['result'])
-            self.assertTrue(result['pass'])
-
-    def test_header_no_referrer_when_downgrade(self):
-        self.reqs['responses']['auto'].headers['Referrer-Policy'] = 'no-referrer-when-downgrade'
-
-        result = referrer_policy(self.reqs)
-
-        self.assertEquals('referrer-policy-no-referrer-when-downgrade', result['result'])
-        self.assertTrue(result['pass'])
-
-    def test_missing(self):
-        result = referrer_policy(self.reqs)
-
-        self.assertEquals('referrer-policy-not-implemented', result['result'])
-        self.assertTrue(result['pass'])
-
-    def test_header_invalid(self):
-        self.reqs['responses']['auto'].headers['Referrer-Policy'] = 'whimsy'
-
-        result = referrer_policy(self.reqs)
-
-        self.assertEquals('referrer-policy-invalid', result['result'])
-        self.assertFalse(result['pass'])
-
-    def test_header_unsafe_url(self):
-        self.reqs['responses']['auto'].headers['Referrer-Policy'] = 'unsafe-url'
-
-        result = referrer_policy(self.reqs)
-
-        self.assertEquals('referrer-policy-unsafe-url', result['result'])
-        self.assertFalse(result['pass'])
-
-    def test_header_origin(self):
-        self.reqs['responses']['auto'].headers['Referrer-Policy'] = 'origin'
-
-        result = referrer_policy(self.reqs)
-
-        self.assertEquals('referrer-policy-origin', result['result'])
-        self.assertFalse(result['pass'])
-
-    def test_header_origin_when_cross_origin(self):
-        self.reqs['responses']['auto'].headers['Referrer-Policy'] = 'origin-when-cross-origin'
-
-        result = referrer_policy(self.reqs)
-
-        self.assertEquals('referrer-policy-origin-when-cross-origin', result['result'])
-        self.assertFalse(result['pass'])


### PR DESCRIPTION
Hi, I tried to add the support for Referrer Policy header.
The scoring is:
1. +5 if the header is set with **no-referrer**, **same-origin**, **strict-origin** or **strict-origin-when-cross-origin**
2. 0 if the header is not implemented or its value is **no-referrer-when-downgrade**
3. -5 if the header is invalid, or is set with **unsafe-url**, **origin** or **origin-when-cross-origin**

This will fix issue #107 
