### PR TITLE
First stab at a local scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ $ pip3 install -r requirements.txt
 >>> from httpobs.scanner.local import scan
 >>> scan('observatory.mozilla.org')  # a scan with default options
 >>> scan('observatory.mozilla.org',  # all the custom options
-         http_port=8080,
-         https_port=8443,
-         path='/foo/bar',
-         cookies={'foo': 'bar'},
-         headers={'X-Foo': 'bar'})
+         http_port=8080,             # http server runs on port 8080
+         https_port=8443,            # https server runs on port 8443
+         path='/foo/bar',            # don't scan /, instead scan /foo/bar
+         cookies={'foo': 'bar'},     # set the "foo" cookie to "bar"
+         headers={'X-Foo': 'bar'},   # send an X-Foo: bar HTTP header
+         verify=False)               # treat self-signed certs as valid for tests like HSTS/HPKP
 ```
 
 ### Running a local scanner with Docker

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ httpobs-local-scan --http-port 8080 --https-port 8443 --path '/foo/bar' \
     --cookies '{"foo": "bar"}' --headers '{"X-Foo": "bar"}' --no-verify mozilla.org
 ```
 
-### Running a local scanner with Docker
+## Running a local scanner with Docker
 * Install [Docker Toolbox](https://www.docker.com/products/docker-toolbox) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 
 ```bash
@@ -72,7 +72,7 @@ $ eval $(docker-machine env http-observatory)
 $ docker-compose up -d
 ```
 
-### Creating a local installation (tested on Ubuntu 15)
+## Creating a local installation (tested on Ubuntu 15)
 ```
 # Install git, postgresql, and redis
 # sudo -s

--- a/README.md
+++ b/README.md
@@ -22,6 +22,26 @@ Sites can be scanned using:
 * Python 3
 * Git
 
+## Running a scan from the local codebase, without DB, for continuous integration
+```bash
+# Install the HTTP Observatory
+$ git clone https://github.com/mozilla/http-observatory.git
+$ cd http-observatory
+$ pip3 install .
+$ pip3 install -r requirements.txt
+```
+
+```python
+>>> from httpobs.scanner.local import scan
+>>> scan('observatory.mozilla.org')  # a scan with default options
+>>> scan('observatory.mozilla.org',  # all the custom options
+         http_port=8080,
+         https_port=8443,
+         path='/foo/bar',
+         cookies={'foo': 'bar'},
+         headers={'X-Foo': 'bar'})
+```
+
 ### Running a local scanner with Docker
 * Install [Docker Toolbox](https://www.docker.com/products/docker-toolbox) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ pip3 install .
 $ pip3 install -r requirements.txt
 ```
 
+### Using the local scanner function calls
 ```python
 >>> from httpobs.scanner.local import scan
 >>> scan('observatory.mozilla.org')  # a scan with default options
@@ -41,6 +42,12 @@ $ pip3 install -r requirements.txt
          cookies={'foo': 'bar'},     # set the "foo" cookie to "bar"
          headers={'X-Foo': 'bar'},   # send an X-Foo: bar HTTP header
          verify=False)               # treat self-signed certs as valid for tests like HSTS/HPKP
+```
+
+### The same, but with the local CLI
+```bash
+$ httpobs-local-scan --http-port 8080 --https-port 8443 --path '/foo/bar' \
+    --cookies '{"foo": "bar"}' --headers '{"X-Foo": "bar"} --no-verify mozilla.org
 ```
 
 ### Running a local scanner with Docker

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ pip3 install -r requirements.txt
 ### The same, but with the local CLI
 ```bash
 $ httpobs-local-scan --http-port 8080 --https-port 8443 --path '/foo/bar' \
-    --cookies '{"foo": "bar"}' --headers '{"X-Foo": "bar"} --no-verify mozilla.org
+    --cookies '{"foo": "bar"}' --headers '{"X-Foo": "bar"}' --no-verify mozilla.org
 ```
 
 ### Running a local scanner with Docker

--- a/httpobs/database/database.py
+++ b/httpobs/database/database.py
@@ -113,6 +113,7 @@ def insert_scan_grade(scan_id, scan_grade, scan_score) -> dict:
         return dict(cur.fetchone())
 
 
+# TODO: Separate out some of this logic so it doesn't need to be duplicated in local.scan()
 def insert_test_results(site_id: int, scan_id: int, tests: list, response_headers: dict) -> dict:
     with get_cursor() as cur:
         tests_failed = tests_passed = 0
@@ -273,8 +274,8 @@ def select_site_headers(hostname: str) -> dict:
             headers.update(private_headers)
 
             return {
-                'headers': headers,
-                'cookies': {} if row.get('cookies') is None else row.get('cookies')
+                'cookies': {} if row.get('cookies') is None else row.get('cookies'),
+                'headers': headers
             }
         else:
             return {}

--- a/httpobs/scanner/analyzer/content.py
+++ b/httpobs/scanner/analyzer/content.py
@@ -138,7 +138,7 @@ def subresource_integrity(reqs: dict, expectation='sri-implemented-and-external-
     else:
         # Try to parse the HTML
         try:
-            soup = bs(reqs['resources']['/'], 'html.parser')
+            soup = bs(reqs['resources']['__path__'], 'html.parser')
         except:
             output['result'] = 'html-not-parsable'
             return output

--- a/httpobs/scanner/analyzer/utils.py
+++ b/httpobs/scanner/analyzer/utils.py
@@ -14,7 +14,6 @@ hsts = {}
 
 # Download the Google HSTS Preload List
 try:
-    print('Retrieving the Chromium HSTS preload list', file=sys.stderr)
     r = b64decode(requests.get(HSTS_URL).text).decode('utf-8').split('\n')
 
     # Remove all the comments
@@ -39,9 +38,6 @@ try:
             'mode': 'force-https',
             'pinned': True
         }
-
-    # Print confirmation that preload list has been successfully downloaded and parsed
-    print('Successfully downloaded and parsed the Chromium HSTS preload list', file=sys.stderr)
 except:
     print('Unable to download the Chromium HSTS preload list; exiting', file=sys.stderr)
     exit(1)

--- a/httpobs/scanner/local.py
+++ b/httpobs/scanner/local.py
@@ -17,6 +17,9 @@ def scan(hostname, **kwargs):
         http_port (int): port to scan for HTTP, instead of 80
         https_port (int): port to be scanned for HTTPS, instead of 443
         path (str): path to scan, instead of "/"
+        verify (bool): whether to enable or disable certificate verification,
+            enabled by default. This can allow tested sites to pass the HSTS
+            and HPKP tests, even with self-signed certificates.
 
         cookies (dict): Cookies sent to the system being scanned. Matches the
             requests cookie dict.

--- a/httpobs/scanner/local.py
+++ b/httpobs/scanner/local.py
@@ -1,12 +1,8 @@
-import argparse
 import httpobs.conf
-import json
 
 from httpobs.scanner.analyzer import NUM_TESTS, tests
 from httpobs.scanner.grader import get_grade_and_likelihood_for_score, get_score_description
 from httpobs.scanner.retriever import retrieve_all
-
-from operator import itemgetter
 
 
 def scan(hostname, **kwargs):
@@ -78,84 +74,3 @@ def scan(hostname, **kwargs):
         },
         'tests': {result.pop('name'): result for result in results}
     })
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-
-    # Add the various arguments
-    parser.add_argument('--http-port',
-                        default=80,
-                        help='port to use for the HTTP scan (instead of 80)',
-                        type=int)
-    parser.add_argument('--https-port',
-                        default=443,
-                        help='port to use for the HTTPS scan (instead of 443)',
-                        type=int)
-    parser.add_argument('--path',
-                        default=argparse.SUPPRESS,
-                        help='path to scan, instead of /',
-                        type=str)
-    parser.add_argument('--no-verify',
-                        action='store_true',
-                        help='disable certificate verification in the HSTS/HPKP tests')
-    parser.add_argument('--cookies',
-                        default=argparse.SUPPRESS,
-                        help='cookies to send in scan (json formatted)',
-                        type=json.loads)
-    parser.add_argument('--headers',
-                        default=argparse.SUPPRESS,
-                        help='headers to send in scan (json formatted)',
-                        type=str)
-    parser.add_argument('--format',
-                        default='json',
-                        help='output format (json or report), default of json',
-                        type=str)
-    parser.add_argument('hostname',
-                        help='host to scan',
-                        type=str)
-
-    args = vars(parser.parse_args())
-
-    # Remove the -- from the name, change - to underscore
-    args = {k.split('--')[-1].replace('-', '_'): v for k, v in args.items()}
-    format = args.pop('format').lower()
-
-    # print out help if no arguments are specified, or bad arguments
-    if len(args) == 0 or format not in ('json', 'report'):
-        parser.print_help()
-        parser.exit(-1)
-
-    # Because it makes sense this way
-    if args['http_port'] == 80:
-        del(args['http_port'])
-
-    if args['https_port'] == 443:
-        del (args['https_port'])
-
-    if args.pop('no_verify'):
-        args['verify'] = False
-
-    # Get the scan results
-    r = scan(**args)
-
-    # print out the results to the command line
-    if format == 'json':
-        print(json.dumps(r, indent=4, sort_keys=True))
-    elif format == 'report':
-        print('Score: {0} [{1}]'.format(r['scan']['score'],
-                                        r['scan']['grade']))
-
-        print('Modifiers:')
-
-        # Get all the scores by test name
-        scores = [[k.replace('-', ' ').title(), v['score_modifier'], v['score_description']]
-                  for k, v in r['tests'].items()]
-        scores = sorted(scores, key=itemgetter(0))  # [('test1', -5, 'foo'), ('test2', -10, 'bar')]
-
-        for score in scores:
-            if score[1] > 0:
-                score[1] = '+' + str(score[1])  # display 5 as +5
-            print('  {test:<30} [{modifier:>3}]  {reason}'.format(test=score[0],
-                                                                  modifier=score[1],
-                                                                  reason=score[2]))

--- a/httpobs/scanner/local.py
+++ b/httpobs/scanner/local.py
@@ -1,0 +1,71 @@
+import httpobs.conf
+
+from httpobs.scanner.analyzer import NUM_TESTS, tests
+from httpobs.scanner.grader import get_grade_and_likelihood_for_score
+from httpobs.scanner.retriever import retrieve_all
+
+
+def scan(hostname, **kwargs):
+    # Always allow localhost scans when run in this way
+    """Performs an Observatory scan, but doesn't require any database/redis
+    backing. Given the lowered security concerns due to not being a public
+    API, you can use this to scan arbitrary ports and paths.
+
+    Args:
+        hostname (str): domain name for host to be scanned
+
+    Kwargs:
+        http_port (int): port to scan for HTTP, instead of 80
+        https_port (int): port to be scanned for HTTPS, instead of 443
+        path (str): path to scan, instead of "/"
+
+        cookies (dict): Cookies sent to the system being scanned. Matches the
+            requests cookie dict.
+        headers (dict): HTTP headers sent to the system being scanned. Format
+            matches the requests headers dict.
+
+    Returns:
+        A dict representing the analyze (scan) and getScanResults (test) API call.  Example:
+
+        {
+            'scan': {
+                'grade': 'A'
+                ...
+            },
+            'test': {
+                'content-security-policy': {
+                    'pass': True
+                    ...
+                }
+            }
+        }
+    """
+    httpobs.conf.SCANNER_ALLOW_LOCALHOST = True
+
+    # Attempt to retrieve all the resources, not capturing exceptions
+    reqs = retrieve_all(hostname, **kwargs)
+
+    # If we can't connect at all, let's abort the test
+    if reqs['responses']['auto'] is None:
+        return {'error': 'site down'}
+
+    # Get all the results
+    results = [test(reqs) for test in tests]
+
+    # Get the score, grade, etc.
+    grades = get_grade_and_likelihood_for_score(100 + sum([result.get('score_modifier', 0) for result in results]))
+    tests_passed = sum([1 if result.get('pass') else 0 for result in results])
+
+    # Return the results
+    return({
+        'scan': {
+            'grade': grades[1],
+            'likelihood_indicator': grades[2],
+            'response_headers': reqs['responses']['auto'].headers,
+            'score': grades[0],
+            'tests_failed': NUM_TESTS - tests_passed,
+            'tests_passed': tests_passed,
+            'tests_quantity': NUM_TESTS,
+        },
+        'tests': {result.pop('name'): result for result in results}
+    })

--- a/httpobs/scanner/local.py
+++ b/httpobs/scanner/local.py
@@ -6,7 +6,6 @@ from httpobs.scanner.retriever import retrieve_all
 
 
 def scan(hostname, **kwargs):
-    # Always allow localhost scans when run in this way
     """Performs an Observatory scan, but doesn't require any database/redis
     backing. Given the lowered security concerns due to not being a public
     API, you can use this to scan arbitrary ports and paths.
@@ -40,6 +39,7 @@ def scan(hostname, **kwargs):
             }
         }
     """
+    # Always allow localhost scans when run in this way
     httpobs.conf.SCANNER_ALLOW_LOCALHOST = True
 
     # Attempt to retrieve all the resources, not capturing exceptions

--- a/httpobs/scanner/local.py
+++ b/httpobs/scanner/local.py
@@ -1,8 +1,12 @@
+import argparse
 import httpobs.conf
+import json
 
 from httpobs.scanner.analyzer import NUM_TESTS, tests
-from httpobs.scanner.grader import get_grade_and_likelihood_for_score
+from httpobs.scanner.grader import get_grade_and_likelihood_for_score, get_score_description
 from httpobs.scanner.retriever import retrieve_all
+
+from operator import itemgetter
 
 
 def scan(hostname, **kwargs):
@@ -54,6 +58,8 @@ def scan(hostname, **kwargs):
 
     # Get all the results
     results = [test(reqs) for test in tests]
+    for result in results:
+        result['score_description'] = get_score_description(result['result'])
 
     # Get the score, grade, etc.
     grades = get_grade_and_likelihood_for_score(100 + sum([result.get('score_modifier', 0) for result in results]))
@@ -64,7 +70,7 @@ def scan(hostname, **kwargs):
         'scan': {
             'grade': grades[1],
             'likelihood_indicator': grades[2],
-            'response_headers': reqs['responses']['auto'].headers,
+            'response_headers': dict(reqs['responses']['auto'].headers),
             'score': grades[0],
             'tests_failed': NUM_TESTS - tests_passed,
             'tests_passed': tests_passed,
@@ -72,3 +78,84 @@ def scan(hostname, **kwargs):
         },
         'tests': {result.pop('name'): result for result in results}
     })
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    # Add the various arguments
+    parser.add_argument('--http-port',
+                        default=80,
+                        help='port to use for the HTTP scan (instead of 80)',
+                        type=int)
+    parser.add_argument('--https-port',
+                        default=443,
+                        help='port to use for the HTTPS scan (instead of 443)',
+                        type=int)
+    parser.add_argument('--path',
+                        default=argparse.SUPPRESS,
+                        help='path to scan, instead of /',
+                        type=str)
+    parser.add_argument('--no-verify',
+                        action='store_true',
+                        help='disable certificate verification in the HSTS/HPKP tests')
+    parser.add_argument('--cookies',
+                        default=argparse.SUPPRESS,
+                        help='cookies to send in scan (json formatted)',
+                        type=json.loads)
+    parser.add_argument('--headers',
+                        default=argparse.SUPPRESS,
+                        help='headers to send in scan (json formatted)',
+                        type=str)
+    parser.add_argument('--format',
+                        default='json',
+                        help='output format (json or report), default of json',
+                        type=str)
+    parser.add_argument('hostname',
+                        help='host to scan',
+                        type=str)
+
+    args = vars(parser.parse_args())
+
+    # Remove the -- from the name, change - to underscore
+    args = {k.split('--')[-1].replace('-', '_'): v for k, v in args.items()}
+    format = args.pop('format').lower()
+
+    # print out help if no arguments are specified, or bad arguments
+    if len(args) == 0 or format not in ('json', 'report'):
+        parser.print_help()
+        parser.exit(-1)
+
+    # Because it makes sense this way
+    if args['http_port'] == 80:
+        del(args['http_port'])
+
+    if args['https_port'] == 443:
+        del (args['https_port'])
+
+    if args.pop('no_verify'):
+        args['verify'] = False
+
+    # Get the scan results
+    r = scan(**args)
+
+    # print out the results to the command line
+    if format == 'json':
+        print(json.dumps(r, indent=4, sort_keys=True))
+    elif format == 'report':
+        print('Score: {0} [{1}]'.format(r['scan']['score'],
+                                        r['scan']['grade']))
+
+        print('Modifiers:')
+
+        # Get all the scores by test name
+        scores = [[k.replace('-', ' ').title(), v['score_modifier'], v['score_description']]
+                  for k, v in r['tests'].items()]
+        scores = sorted(scores, key=itemgetter(0))  # [('test1', -5, 'foo'), ('test2', -10, 'bar')]
+
+        for score in scores:
+            if score[1] > 0:
+                score[1] = '+' + str(score[1])  # display 5 as +5
+            print('  {test:<30} [{modifier:>3}]  {reason}'.format(test=score[0],
+                                                                  modifier=score[1],
+                                                                  reason=score[2]))

--- a/httpobs/scanner/retriever/retriever.py
+++ b/httpobs/scanner/retriever/retriever.py
@@ -5,7 +5,6 @@ from httpobs.conf import (RETRIEVER_CONNECT_TIMEOUT,
                           RETRIEVER_CORS_ORIGIN,
                           RETRIEVER_READ_TIMEOUT,
                           RETRIEVER_USER_AGENT)
-from httpobs.database import select_site_headers
 
 import requests
 
@@ -108,7 +107,15 @@ def __get_page_text(response: requests.Response) -> str:
         return None
 
 
-def retrieve_all(hostname: str) -> dict:
+def retrieve_all(hostname, **kwargs):
+    cookies = kwargs.get('cookies', {})   # HTTP cookies to send, instead of from the database
+    headers = kwargs.get('headers', {})   # HTTP headers to send, instead of from the database
+
+    # This way of doing it keeps the urls tidy even if makes the code ugly
+    http_port = ':' + str(kwargs.get('http_port', '')) if 'http_port' in kwargs else ''
+    https_port = ':' + str(kwargs.get('https_port', '')) if 'https_port' in kwargs else ''
+    path = kwargs.get('path', '/')
+
     retrievals = {
         'hostname': hostname,
         'resources': {
@@ -130,17 +137,13 @@ def retrieve_all(hostname: str) -> dict:
         '/robots.txt'
     )
 
-    # Get the headers and cookies from the database
-    # TODO: Allow headers to be overridden on a per-scan basis?
-    headers = select_site_headers(hostname)
-
     # Create some reusable sessions, one for HTTP and one for HTTPS
-    http_session = __create_session('http://' + hostname + '/',
-                                    headers=headers['headers'],
-                                    cookies=headers['cookies'])
-    https_session = __create_session('https://' + hostname + '/',
-                                     headers=headers['headers'],
-                                     cookies=headers['cookies'])
+    http_session = __create_session('http://' + hostname + http_port + path,
+                                    headers,
+                                    cookies)
+    https_session = __create_session('https://' + hostname + https_port + path,
+                                     headers,
+                                     cookies)
 
     # If neither one works, then the site just can't be loaded
     if not http_session['session'] and not https_session['session']:
@@ -158,11 +161,12 @@ def retrieve_all(hostname: str) -> dict:
             retrievals['responses']['auto'] = http_session['response']
             retrievals['session'] = http_session['session']
 
-        # Store the contents of the base page
-        retrievals['resources']['/'] = __get_page_text(retrievals['responses']['auto'])
+        # Store the contents of the "base" page
+        retrievals['resources']['__path__'] = __get_page_text(retrievals['responses']['auto'])
 
         # Do a CORS preflight request
         retrievals['responses']['cors'] = __get(retrievals['session'],
+                                                path,
                                                 headers={'Origin': RETRIEVER_CORS_ORIGIN})
 
         # Store all the files we retrieve

--- a/httpobs/scripts/httpobs-local-scan
+++ b/httpobs/scripts/httpobs-local-scan
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import httpobs.scanner.local
+
+import argparse
+import json
+
+from operator import itemgetter
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    # Add the various arguments
+    parser.add_argument('--http-port',
+                        default=80,
+                        help='port to use for the HTTP scan (instead of 80)',
+                        type=int)
+    parser.add_argument('--https-port',
+                        default=443,
+                        help='port to use for the HTTPS scan (instead of 443)',
+                        type=int)
+    parser.add_argument('--path',
+                        default=argparse.SUPPRESS,
+                        help='path to scan, instead of /',
+                        type=str)
+    parser.add_argument('--no-verify',
+                        action='store_true',
+                        help='disable certificate verification in the HSTS/HPKP tests')
+    parser.add_argument('--cookies',
+                        default=argparse.SUPPRESS,
+                        help='cookies to send in scan (json formatted)',
+                        type=json.loads)
+    parser.add_argument('--headers',
+                        default=argparse.SUPPRESS,
+                        help='headers to send in scan (json formatted)',
+                        type=str)
+    parser.add_argument('--format',
+                        default='json',
+                        help='output format (json or report), default of json',
+                        type=str)
+    parser.add_argument('hostname',
+                        help='host to scan',
+                        type=str)
+
+    args = vars(parser.parse_args())
+
+    # Remove the -- from the name, change - to underscore
+    args = {k.split('--')[-1].replace('-', '_'): v for k, v in args.items()}
+    output_format = args.pop('format').lower()
+
+    # print out help if no arguments are specified, or bad arguments
+    if len(args) == 0 or output_format not in ('json', 'report'):
+        parser.print_help()
+        parser.exit(-1)
+
+    # Because it makes sense this way
+    if args['http_port'] == 80:
+        del(args['http_port'])
+
+    if args['https_port'] == 443:
+        del (args['https_port'])
+
+    if args.pop('no_verify'):
+        args['verify'] = False
+
+    # Get the scan results
+    r = httpobs.scanner.local.scan(**args)
+
+    # print out the results to the command line
+    if output_format == 'json':
+        print(json.dumps(r, indent=4, sort_keys=True))
+    elif output_format == 'report':
+        print('Score: {0} [{1}]'.format(r['scan']['score'],
+                                        r['scan']['grade']))
+
+        print('Modifiers:')
+
+        # Get all the scores by test name
+        scores = [[k.replace('-', ' ').title(), v['score_modifier'], v['score_description']]
+                  for k, v in r['tests'].items()]
+        scores = sorted(scores, key=itemgetter(0))  # [('test1', -5, 'foo'), ('test2', -10, 'bar')]
+
+        for score in scores:
+            if score[1] > 0:
+                score[1] = '+' + str(score[1])  # display 5 as +5
+            print('  {test:<30} [{modifier:>3}]  {reason}'.format(test=score[0],
+                                                                  modifier=score[1],
+                                                                  reason=score[2]))

--- a/httpobs/tests/unittests/test_content.py
+++ b/httpobs/tests/unittests/test_content.py
@@ -134,7 +134,7 @@ class TestSubResourceIntegrity(TestCase):
         self.reqs = None
 
     def test_no_scripts(self):
-        self.reqs['resources']['/'] = """
+        self.reqs['resources']['__path__'] = """
         <html>
             <head></head>
             <body></body>
@@ -148,7 +148,7 @@ class TestSubResourceIntegrity(TestCase):
 
     def test_not_html(self):
         # invalid html
-        self.reqs['resources']['/'] = '<![..]>'
+        self.reqs['resources']['__path__'] = '<![..]>'
 
         result = subresource_integrity(self.reqs)
 
@@ -157,7 +157,7 @@ class TestSubResourceIntegrity(TestCase):
 
         # json, like what an API might return
         self.reqs['responses']['auto'].headers['Content-Type'] = 'application/json'
-        self.reqs['resources']['/'] = """
+        self.reqs['resources']['__path__'] = """
         {
             'foo': 'bar'
         }
@@ -177,7 +177,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertFalse(result['pass'])
 
     def test_same_origin(self):
-        self.reqs['resources']['/'] = """
+        self.reqs['resources']['__path__'] = """
         <html>
             <head>
               <script src="/static/js/foo.js"></script>
@@ -192,7 +192,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertTrue(result['pass'])
 
         # On the same second-level domain
-        self.reqs['resources']['/'] = """
+        self.reqs['resources']['__path__'] = """
         <html>
             <head>
               <script src="https://www.mozilla.org/static/js/foo.js"></script>
@@ -208,7 +208,7 @@ class TestSubResourceIntegrity(TestCase):
 
     def test_implemented_external_scripts_https(self):
         # load from a remote site
-        self.reqs['resources']['/'] = """
+        self.reqs['resources']['__path__'] = """
         <html>
           <head>
             <script src="/static/js/foo.js"></script>
@@ -227,7 +227,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertTrue(result['pass'])
 
         # load from an intranet / localhost
-        self.reqs['resources']['/'] = """
+        self.reqs['resources']['__path__'] = """
         <html>
           <head>
             <script src="/static/js/foo.js"></script>
@@ -246,7 +246,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertTrue(result['pass'])
 
     def test_implemented_same_origin(self):
-        self.reqs['resources']['/'] = """
+        self.reqs['resources']['__path__'] = """
         <html>
           <head>
             <script src="/static/js/react-0.14.7.min.js"
@@ -264,7 +264,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertTrue(result['pass'])
 
     def test_not_implemented_external_scripts_https(self):
-        self.reqs['resources']['/'] = """
+        self.reqs['resources']['__path__'] = """
         <html>
           <head>
             <script src="/static/js/foo.js"></script>
@@ -280,7 +280,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertFalse(result['pass'])
 
     def test_implemented_external_scripts_http(self):
-        self.reqs['resources']['/'] = """
+        self.reqs['resources']['__path__'] = """
         <html>
           <head>
             <script src="/static/js/foo.js"></script>
@@ -301,7 +301,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertFalse(result['pass'])
 
     def test_not_implemented_external_scripts_http(self):
-        self.reqs['resources']['/'] = """
+        self.reqs['resources']['__path__'] = """
         <html>
           <head>
             <script src="/static/js/foo.js"></script>

--- a/httpobs/tests/unittests/test_retriever.py
+++ b/httpobs/tests/unittests/test_retriever.py
@@ -25,7 +25,7 @@ class TestRetriever(TestCase):
         reqs = retrieve_all('mozilla.org')
 
         # Various things we know about mozilla.org
-        self.assertIsNotNone(reqs['resources']['/'])
+        self.assertIsNotNone(reqs['resources']['__path__'])
         self.assertIsNotNone(reqs['resources']['/contribute.json'])
         self.assertIsNotNone(reqs['resources']['/robots.txt'])
         self.assertIsNone(reqs['resources']['/clientaccesspolicy.xml'])

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
     author_email='april@mozilla.com',
     packages=find_packages(),
     include_package_data=True,
-    scripts=['httpobs/scripts/httpobs-mass-scan',
+    scripts=['httpobs/scripts/httpobs-local-scan',
+             'httpobs/scripts/httpobs-mass-scan',
              'httpobs/scripts/httpobs-scan-worker'],
     zip_safe=False,
 )


### PR DESCRIPTION
Adds httpobs.scanner.local.scan().  This allows you to run synchronous scans without needing a database for storage, or redis/celery to conduct scans.

This addresses:
https://github.com/mozilla/http-observatory/issues/157
https://github.com/mozilla/http-observatory/issues/76
https://github.com/mozilla/http-observatory/issues/66