### PR TITLE
Improve CLI scanner detection/refusal of invalid hostnames

### DIFF
--- a/httpobs/scanner/local.py
+++ b/httpobs/scanner/local.py
@@ -11,7 +11,8 @@ def scan(hostname, **kwargs):
     API, you can use this to scan arbitrary ports and paths.
 
     Args:
-        hostname (str): domain name for host to be scanned
+        hostname (str): domain name for host to be scanned. Must not include
+            protocol (http://, https://) or port number (:80).
 
     Kwargs:
         http_port (int): port to scan for HTTP, instead of 80

--- a/httpobs/scripts/httpobs-local-scan
+++ b/httpobs/scripts/httpobs-local-scan
@@ -6,6 +6,7 @@ import argparse
 import json
 
 from operator import itemgetter
+from urllib.parse import urlparse
 
 
 if __name__ == "__main__":
@@ -40,7 +41,7 @@ if __name__ == "__main__":
                         help='output format (json or report), default of json',
                         type=str)
     parser.add_argument('hostname',
-                        help='host to scan',
+                        help='host to scan (hostname only, no protocol or port)',
                         type=str)
 
     args = vars(parser.parse_args())
@@ -51,6 +52,14 @@ if __name__ == "__main__":
 
     # print out help if no arguments are specified, or bad arguments
     if len(args) == 0 or output_format not in ('json', 'report'):
+        parser.print_help()
+        parser.exit(-1)
+
+    # port can't be appended to hostname because we need both HTTP and HTTPS ports.
+    # protocol can't be prefixed either, as we scan both of those ports.
+    #
+    # use urlparse to ensure that neither of these are present in the hostname.
+    if urlparse(args['hostname']).scheme or urlparse('http://' + args['hostname']).port:
         parser.print_help()
         parser.exit(-1)
 


### PR DESCRIPTION
The CLI scanner did not refuse hostnames on sight for containing a protocol prefix or port suffix. This adds a simple test to reject these things on contact, and improves the documentation in two places (CLI usage and ```local.py```:```scan()```) to clearly state this requirement.

I'm not convinced this is the correct way to introduce this logic. If it exists elsewhere, maybe this should import that somehow and use it instead (repairing if necessary).

Tested to reject only the expected inputs, but requesting review of my entire approach at all. Closes #192 if merged.