### PR TITLE
Various CSP description improvements

### DIFF
--- a/httpobs/docs/scoring.md
+++ b/httpobs/docs/scoring.md
@@ -63,7 +63,7 @@ csp-implemented-with-no-unsafe | Content Security Policy (CSP) implemented witho
 csp-implemented-with-unsafe-inline-in-style-src-only | Content Security Policy (CSP) implemented with unsafe directives inside `style-src`. This includes `'unsafe-inline'`, `data:`, or overly broad sources such as `https:`. | 0
 csp-implemented-with-unsafe-eval | Content Security Policy (CSP) implemented unsafely, with `'unsafe-eval'` | -10
 csp-implemented-with-insecure-scheme | Content Security Policy (CSP) implemented, but secure site allows resources to be loaded from http | -20
-csp-implemented-with-unsafe-inline | Content Security Policy (CSP) implemented unsafely. This includes `'unsafe-inline'` or `data:` inside `script-src`, overly broad sources such as `https:` inside `object-src` or `script-src`, or not restricting the sources for `object-src` or `script-src`. | -20
+csp-implemented-with-unsafe-inline | Content Security Policy (CSP) implemented unsafely. This includes: `'unsafe-inline'` or `data:` inside `script-src`; overly broad sources such as `https:` inside `object-src` or `script-src`; or not restricting the sources for `object-src` or `script-src`. | -20
 csp-not-implemented | Content Security Policy (CSP) header not implemented | -25
 csp-header-invalid | Content Security Policy (CSP) header cannot be parsed successfully | -25
 <br>

--- a/httpobs/docs/scoring.md
+++ b/httpobs/docs/scoring.md
@@ -60,10 +60,10 @@ cross-origin-resource-sharing-<br>implemented-with-universal-access | Content is
 --- | --- | :---:
 csp-implemented-with-no-unsafe-default-src-none | Content Security Policy (CSP) implemented with `default-src 'none'` and without `'unsafe-inline'` or `'unsafe-eval'` | 10
 csp-implemented-with-no-unsafe | Content Security Policy (CSP) implemented without `'unsafe-inline'` or `'unsafe-eval'` | 5
-csp-implemented-with-unsafe-inline-in-style-src-only | Content Security Policy (CSP) implemented with unsafe directives inside `style-src`. This includes 'unsafe-inline', `data:`, or overly broad sources such as `https:`. | 0
+csp-implemented-with-unsafe-inline-in-style-src-only | Content Security Policy (CSP) implemented with unsafe directives inside `style-src`. This includes `'unsafe-inline'`, `data:`, or overly broad sources such as `https:`. | 0
 csp-implemented-with-unsafe-eval | Content Security Policy (CSP) implemented, but allows `'unsafe-eval'` | -10
 csp-implemented-with-insecure-scheme | Content Security Policy (CSP) implemented, but secure site allows resources to be loaded from http | -20
-csp-implemented-with-unsafe-inline | Content Security Policy (CSP) implemented unsafely. This includes `\'unsafe-inline\'` or `data:` inside script-src, overly broad sources such as `https:` inside `object-src` or `script-src`, or not restricting the sources for `object-src` or `script-src`. | -20
+csp-implemented-with-unsafe-inline | Content Security Policy (CSP) implemented unsafely. This includes `'unsafe-inline'` or `data:` inside `script-src`, overly broad sources such as `https:` inside `object-src` or `script-src`, or not restricting the sources for `object-src` or `script-src`. | -20
 csp-not-implemented | Content Security Policy (CSP) header not implemented | -25
 csp-header-invalid | Content Security Policy (CSP) header cannot be parsed successfully | -25
 <br>

--- a/httpobs/docs/scoring.md
+++ b/httpobs/docs/scoring.md
@@ -61,7 +61,7 @@ cross-origin-resource-sharing-<br>implemented-with-universal-access | Content is
 csp-implemented-with-no-unsafe-default-src-none | Content Security Policy (CSP) implemented with `default-src 'none'` and without `'unsafe-inline'` or `'unsafe-eval'` | 10
 csp-implemented-with-no-unsafe | Content Security Policy (CSP) implemented without `'unsafe-inline'` or `'unsafe-eval'` | 5
 csp-implemented-with-unsafe-inline-in-style-src-only | Content Security Policy (CSP) implemented with unsafe directives inside `style-src`. This includes `'unsafe-inline'`, `data:`, or overly broad sources such as `https:`. | 0
-csp-implemented-with-unsafe-eval | Content Security Policy (CSP) implemented, but allows `'unsafe-eval'` | -10
+csp-implemented-with-unsafe-eval | Content Security Policy (CSP) implemented unsafely, with `'unsafe-eval'` | -10
 csp-implemented-with-insecure-scheme | Content Security Policy (CSP) implemented, but secure site allows resources to be loaded from http | -20
 csp-implemented-with-unsafe-inline | Content Security Policy (CSP) implemented unsafely. This includes `'unsafe-inline'` or `data:` inside `script-src`, overly broad sources such as `https:` inside `object-src` or `script-src`, or not restricting the sources for `object-src` or `script-src`. | -20
 csp-not-implemented | Content Security Policy (CSP) header not implemented | -25


### PR DESCRIPTION
These commits tries to clean up, to some extent, the wording surrounding CSP score descriptions.

Closes #186 if merged, but please don't merge yet. I'm pretty confident this is *not* a complete set of the changes necessary to make this a complete pull request. What process copies the descriptions from ```docs/scoring.md``` into ```httpobs/scanner/grader/grade.py```?

cd67c25: The quoting in ```scoring.md``` wasn't consistent between the CSP rules, so I tried to repair them.

6473414: The description of ```unsafe-eval``` was worded slightly differently from the others like it, so I altered it to match.

37a26b1: I tried to use colons and semicolons to slightly improve the readability of the description. It's not *much* better, because it's a compact expression of technical terms, but it's slightly better:

```Content Security Policy (CSP) implemented unsafely. This includes: `'unsafe-inline'` or `data:` inside `script-src`; overly broad sources such as `https:` inside `object-src` or `script-src`; or not restricting the sources for `object-src` or `script-src`.```