### PR TITLE
Added debugging for DB connection failures

### DIFF
--- a/httpobs/database/database.py
+++ b/httpobs/database/database.py
@@ -47,7 +47,8 @@ class SimpleDatabaseConnection:
                 print('INFO: Connected to PostgreSQL', file=sys.stderr)
             self._connected = True
 
-        except:
+        except Exception as e:
+            print(e, file=sys.stderr)
             self._conn = SimpleNamespace(closed=1)
 
             if self._connected:


### PR DESCRIPTION
Really simple debugging statement that turns 
```
*** Operational MODE: preforking ***
WARNING: Disconnected from PostgreSQL
WARNING: Unable to connect to PostgreSQL.
```
Into 
```
*** Operational MODE: preforking ***
FATAL: could not translate host name "my.postgres.url" to address: Name or service not known
WARNING: Disconnected from PostgreSQL
FATAL: could not translate host name "my.postgres.url" to address: Name or service not known
WARNING: Unable to connect to PostgreSQL.
```

```
*** Operational MODE: preforking ***
FATAL:  password authentication failed for user "httpobs"
WARNING: Disconnected from PostgreSQL
FATAL:  password authentication failed for user "httpobs"
WARNING: Unable to connect to PostgreSQL.
```
