### PR TITLE
Change CSP test for insecure schemes

### DIFF
--- a/httpobs/docs/scoring.md
+++ b/httpobs/docs/scoring.md
@@ -61,6 +61,7 @@ cross-origin-resource-sharing-<br>implemented-with-universal-access | Content is
 csp-implemented-with-no-unsafe-default-src-none | Content Security Policy (CSP) implemented with `default-src 'none'` and without `'unsafe-inline'` or `'unsafe-eval'` | 10
 csp-implemented-with-no-unsafe | Content Security Policy (CSP) implemented without `'unsafe-inline'` or `'unsafe-eval'` | 5
 csp-implemented-with-unsafe-inline-in-style-src-only | Content Security Policy (CSP) implemented with unsafe directives inside `style-src`. This includes 'unsafe-inline', `data:`, or overly broad sources such as `https:`. | 0
+csp-implemented-with-insecure-scheme-in-passive-content-only | Content Security Policy (CSP) implemented, but secure site allows images or media to be loaded over http | -5
 csp-implemented-with-unsafe-eval | Content Security Policy (CSP) implemented, but allows `'unsafe-eval'` | -10
 csp-implemented-with-insecure-scheme | Content Security Policy (CSP) implemented, but secure site allows resources to be loaded from http | -20
 csp-implemented-with-unsafe-inline | Content Security Policy (CSP) implemented unsafely. This includes `\'unsafe-inline\'` or `data:` inside script-src, overly broad sources such as `https:` inside `object-src` or `script-src`, or not restricting the sources for `object-src` or `script-src`. | -20

--- a/httpobs/docs/scoring.md
+++ b/httpobs/docs/scoring.md
@@ -61,7 +61,7 @@ cross-origin-resource-sharing-<br>implemented-with-universal-access | Content is
 csp-implemented-with-no-unsafe-default-src-none | Content Security Policy (CSP) implemented with `default-src 'none'` and without `'unsafe-inline'` or `'unsafe-eval'` | 10
 csp-implemented-with-no-unsafe | Content Security Policy (CSP) implemented without `'unsafe-inline'` or `'unsafe-eval'` | 5
 csp-implemented-with-unsafe-inline-in-style-src-only | Content Security Policy (CSP) implemented with unsafe directives inside `style-src`. This includes 'unsafe-inline', `data:`, or overly broad sources such as `https:`. | 0
-csp-implemented-with-insecure-scheme-in-passive-content-only | Content Security Policy (CSP) implemented, but secure site allows images or media to be loaded over http | -5
+csp-implemented-with-insecure-scheme-in-passive-content-only | Content Security Policy (CSP) implemented, but secure site allows images or media to be loaded over http | -10
 csp-implemented-with-unsafe-eval | Content Security Policy (CSP) implemented, but allows `'unsafe-eval'` | -10
 csp-implemented-with-insecure-scheme | Content Security Policy (CSP) implemented, but secure site allows resources to be loaded from http | -20
 csp-implemented-with-unsafe-inline | Content Security Policy (CSP) implemented unsafely. This includes `\'unsafe-inline\'` or `data:` inside script-src, overly broad sources such as `https:` inside `object-src` or `script-src`, or not restricting the sources for `object-src` or `script-src`. | -20

--- a/httpobs/scanner/analyzer/headers.py
+++ b/httpobs/scanner/analyzer/headers.py
@@ -173,14 +173,14 @@ def content_security_policy(reqs: dict, expectation='csp-implemented-with-no-uns
     elif script_src.union(style_src).intersection({'\'unsafe-eval\''}):
         output['result'] = 'csp-implemented-with-unsafe-eval'
 
-    # Don't allow 'unsafe-inline', data:, or overly broad sources in style-src
-    elif style_src.intersection(DANGEROUSLY_BROAD + UNSAFE_INLINE):
-        output['result'] = 'csp-implemented-with-unsafe-inline-in-style-src-only'
-
     # If the site is https, it shouldn't allow any http: as a source (active content)
     elif (urlparse(response.url).scheme == 'https' and
           [source for source in passive_csp_sources if 'http:' in source or 'ftp:' in source]):
         output['result'] = 'csp-implemented-with-insecure-scheme-in-passive-content-only'
+
+    # Don't allow 'unsafe-inline', data:, or overly broad sources in style-src
+    elif style_src.intersection(DANGEROUSLY_BROAD + UNSAFE_INLINE):
+        output['result'] = 'csp-implemented-with-unsafe-inline-in-style-src-only'
 
     # Only if default-src is 'none' and 'none' alone, since additional uris override 'none'
     elif csp.get('default-src') == {'\'none\''}:

--- a/httpobs/scanner/analyzer/headers.py
+++ b/httpobs/scanner/analyzer/headers.py
@@ -39,6 +39,7 @@ def __parse_csp(csp_string: str) -> dict:
         if not entry:  # Catch errant semi-colons
             continue
 
+        # Why not use .lower()? See: https://github.com/w3c/webappsec-csp/issues/236
         directive = entry[0]
 
         # Technically the path part of any source is case-sensitive, but since we don't test
@@ -63,6 +64,8 @@ def content_security_policy(reqs: dict, expectation='csp-implemented-with-no-uns
     :param expectation: test expectation
         csp-implemented-with-no-unsafe: CSP implemented with no unsafe inline keywords [default]
         csp-implemented-with-unsafe-in-style-src-only: Allow the 'unsafe' keyword in style-src only
+        csp-implemented-with-insecure-scheme-in-passive-content-only:
+          CSP implemented with insecure schemes (http, ftp) in img/media-src
         csp-implemented-with-unsafe-inline: CSP implemented with unsafe-inline
         csp-implemented-with-unsafe-eval: CSP implemented with unsafe-eval
         csp-implemented-with-insecure-scheme: CSP implemented with having sources over http:
@@ -89,8 +92,11 @@ def content_security_policy(reqs: dict, expectation='csp-implemented-with-no-uns
     # TODO: try to parse when there are multiple CSP headers
 
     # Obviously you can get around it with things like https://*.org, but you're only hurting yourself
-    dangerously_broad = ['http:', 'https:', '*', 'http://*', 'http://*.*', 'https://*', 'https://*.*']
-    unsafe_inline = ['\'unsafe-inline\'', 'data:']
+    DANGEROUSLY_BROAD = ('ftp:', 'http:', 'https:', '*', 'http://*', 'http://*.*', 'https://*', 'https://*.*')
+    UNSAFE_INLINE = ('\'unsafe-inline\'', 'data:')
+
+    # Passive content check
+    PASSIVE_DIRECTIVES = ('img-src', 'media-src')
 
     # First we need to combine the HTTP header and HTTP Equiv "header"
     try:
@@ -131,6 +137,13 @@ def content_security_policy(reqs: dict, expectation='csp-implemented-with-no-uns
     else:
         csp = headers['http'] or headers['meta']
 
+    # Some checks look only at active/passive CSP directives
+    # This could be inlined, but the code is quite hard to read at that point
+    active_csp_sources = [source for directive, source_list in csp.items() for source in source_list if
+                          directive not in PASSIVE_DIRECTIVES]
+    passive_csp_sources = [source for directive, source_list in csp.items() for source in source_list if
+                           directive in PASSIVE_DIRECTIVES]
+
     # Get the various directives we look at
     object_src = csp.get('object-src') or csp.get('default-src') or {'*'}
     script_src = csp.get('script-src') or csp.get('default-src') or {'*'}
@@ -147,12 +160,13 @@ def content_security_policy(reqs: dict, expectation='csp-implemented-with-no-uns
     # No 'unsafe-inline' or data: in script-src
     # Also don't allow overly broad schemes such as https: in either object-src or script-src
     # Likewise, if you don't have object-src or script-src defined, then all sources are allowed
-    if (script_src.intersection(dangerously_broad + unsafe_inline) or
-       object_src.intersection(dangerously_broad)):
+    if (script_src.intersection(DANGEROUSLY_BROAD + UNSAFE_INLINE) or
+       object_src.intersection(DANGEROUSLY_BROAD)):
         output['result'] = 'csp-implemented-with-unsafe-inline'
 
-    # If the site is https, it shouldn't allow any http: as a source (passive or mixed content)
-    elif urlparse(response.url).scheme == 'https' and [d for d in set.union(*csp.values()) if 'http:' in d]:
+    # If the site is https, it shouldn't allow any http: as a source (active content)
+    elif (urlparse(response.url).scheme == 'https' and
+          [source for source in active_csp_sources if 'http:' in source or 'ftp:' in source]):
         output['result'] = 'csp-implemented-with-insecure-scheme'
 
     # Don't allow 'unsafe-eval' in script-src or style-src
@@ -160,8 +174,13 @@ def content_security_policy(reqs: dict, expectation='csp-implemented-with-no-uns
         output['result'] = 'csp-implemented-with-unsafe-eval'
 
     # Don't allow 'unsafe-inline', data:, or overly broad sources in style-src
-    elif style_src.intersection(dangerously_broad + unsafe_inline):
+    elif style_src.intersection(DANGEROUSLY_BROAD + UNSAFE_INLINE):
         output['result'] = 'csp-implemented-with-unsafe-inline-in-style-src-only'
+
+    # If the site is https, it shouldn't allow any http: as a source (active content)
+    elif (urlparse(response.url).scheme == 'https' and
+          [source for source in passive_csp_sources if 'http:' in source or 'ftp:' in source]):
+        output['result'] = 'csp-implemented-with-insecure-scheme-in-passive-content-only'
 
     # Only if default-src is 'none' and 'none' alone, since additional uris override 'none'
     elif csp.get('default-src') == {'\'none\''}:
@@ -180,7 +199,8 @@ def content_security_policy(reqs: dict, expectation='csp-implemented-with-no-uns
     # Check to see if the test passed or failed
     if output['result'] in (expectation,
                             'csp-implemented-with-no-unsafe-default-src-none',
-                            'csp-implemented-with-unsafe-inline-in-style-src-only'):
+                            'csp-implemented-with-unsafe-inline-in-style-src-only',
+                            'csp-implemented-with-insecure-scheme-in-passive-content-only'):
         output['pass'] = True
 
     return output

--- a/httpobs/scanner/grader/grade.py
+++ b/httpobs/scanner/grader/grade.py
@@ -79,7 +79,7 @@ SCORE_TABLE = {
     'csp-implemented-with-insecure-scheme-in-passive-content-only': {
         'description': ('Content Security Policy (CSP) implemented, '
                         'but secure site allows images or media to be loaded over http'),
-        'modifier': -5,
+        'modifier': -10,
     },
     'csp-implemented-with-unsafe-eval': {
         'description': 'Content Security Policy (CSP) implemented, but allows \'unsafe-eval\'',

--- a/httpobs/scanner/grader/grade.py
+++ b/httpobs/scanner/grader/grade.py
@@ -76,6 +76,11 @@ SCORE_TABLE = {
                         'This includes \'unsafe-inline\', data: or overly broad sources such as https:.'),
         'modifier': 0,
     },
+    'csp-implemented-with-insecure-scheme-in-passive-content-only': {
+        'description': ('Content Security Policy (CSP) implemented, '
+                        'but secure site allows images or media to be loaded over http'),
+        'modifier': -5,
+    },
     'csp-implemented-with-unsafe-eval': {
         'description': 'Content Security Policy (CSP) implemented, but allows \'unsafe-eval\'',
         'modifier': -10,

--- a/httpobs/tests/unittests/test_headers.py
+++ b/httpobs/tests/unittests/test_headers.py
@@ -67,6 +67,7 @@ class TestContentSecurityPolicy(TestCase):
             "default-src 'none'; img-src https:; media-src http://mozilla.org",
             "default-src 'none'; img-src http: https:; script-src 'self'; style-src 'self'",
             "default-src 'none'; img-src 'none'; media-src http:; script-src 'self'; style-src 'self'",
+            "default-src 'none'; img-src 'none'; media-src http:; script-src 'self'; style-src 'unsafe-inline'",
         )
 
         for value in values:


### PR DESCRIPTION
Sites that contain insecure sources inside passive sources won't be penalized as heavily. There are many meta-blogs that pull images from everywhere. While not great, it's not the worst. I may adjust the penalty in the future.