### PR TITLE
Don't penalize 'unsafe-inline' + hash/nonce source in style-src

### DIFF
--- a/httpobs/scanner/analyzer/headers.py
+++ b/httpobs/scanner/analyzer/headers.py
@@ -167,10 +167,12 @@ def content_security_policy(reqs: dict, expectation='csp-implemented-with-no-uns
     script_src = csp.get('script-src') or csp.get('default-src') or {'*'}
     style_src = csp.get('style-src') or csp.get('default-src') or {'*'}
 
-    # Remove 'unsafe-inline' if nonce or hash are used are in script-src
+    # Remove 'unsafe-inline' if nonce or hash are used in script-src or style-src
     # See: https://github.com/mozilla/http-observatory/issues/88
-    if any(source.startswith(NONCES_HASHES) for source in script_src) and '\'unsafe-inline\'' in script_src:
-        script_src.remove('\'unsafe-inline\'')
+    #      https://github.com/mozilla/http-observatory/issues/277
+    for source_list in (script_src, style_src):
+        if any(source.startswith(NONCES_HASHES) for source in source_list) and '\'unsafe-inline\'' in source_list:
+            source_list.remove('\'unsafe-inline\'')
 
     # If a script-src uses 'strict-dynamic', we need to:
     # 1. Check to make sure there's a valid nonce/hash source

--- a/httpobs/tests/unittests/test_headers.py
+++ b/httpobs/tests/unittests/test_headers.py
@@ -129,7 +129,10 @@ class TestContentSecurityPolicy(TestCase):
                   "default-src 'none';;; ;;;style-src 'self' 'unsafe-inline'",
                   "default-src 'none'; style-src data:",
                   "default-src 'none'; style-src *",
-                  "default-src 'none'; style-src https:")
+                  "default-src 'none'; style-src https:",
+                  "default-src 'none'; style-src 'unsafe-inline'; " +
+                  "script-src 'sha256-hqBEA/HXB3aJU2FgOnYN8rkAgEVgyfi3Vs1j2/XMPBB=' " +
+                  "'unsafe-inline'")
 
         for value in values:
             self.reqs['responses']['auto'].headers['Content-Security-Policy'] = value
@@ -141,7 +144,8 @@ class TestContentSecurityPolicy(TestCase):
             self.assertTrue(result['policy']['unsafeInlineStyle'])
 
     def test_no_unsafe(self):
-        # See https://github.com/mozilla/http-observatory/issues/88 for 'unsafe-inline' + hash/nonce
+        # See https://github.com/mozilla/http-observatory/issues/88 and
+        # https://github.com/mozilla/http-observatory/issues/277 for 'unsafe-inline' + hash/nonce
         values = ("default-src https://mozilla.org",
                   "default-src https://mozilla.org;;; ;;;script-src 'none'",
                   "object-src 'none'; script-src https://mozilla.org; " +
@@ -152,7 +156,10 @@ class TestContentSecurityPolicy(TestCase):
                   "object-src 'none'; style-src 'self'; script-src 'unsafe-inline' " +
                   "'sha256-hqBEA/HXB3aJU2FgOnYN8rkAgEVgyfi3Vs1j2/XMPBA='" +
                   "'sha256-hqBEA/HXB3aJU2FgOnYN8rkAgEVgyfi3Vs1j2/XMPBB='",
-                  "object-src 'none'; script-src 'unsafe-inline' 'nonce-abc123' 'unsafe-inline'; style-src 'none'")
+                  "object-src 'none'; script-src 'unsafe-inline' 'nonce-abc123' 'unsafe-inline'; style-src 'none'",
+                  "default-src https://mozilla.org; style-src 'unsafe-inline' 'nonce-abc123' 'unsafe-inline'",
+                  "default-src https://mozilla.org; style-src 'unsafe-inline' " +
+                  "'sha256-hqBEA/HXB3aJU2FgOnYN8rkAgEVgyfi3Vs1j2/XMPBB=' 'unsafe-inline'")
 
         for value in values:
             self.reqs['responses']['auto'].headers['Content-Security-Policy'] = value


### PR DESCRIPTION
This fixes #277 by implicitly removing 'unsafe-inline' from style-src that also contain at least one nonce or hash source.