### PR TITLE
bump up scanner requirements to latest releases

### DIFF
--- a/httpobs/scanner/requirements.txt
+++ b/httpobs/scanner/requirements.txt
@@ -1,3 +1,3 @@
-psutil==5.4.2
-publicsuffixlist==0.4.3
-requests==2.14.2
+psutil==5.4.3
+publicsuffixlist==0.5.0
+requests==2.18.4


### PR DESCRIPTION
I noted that there has been forward progress on the three requirements specific to the scanner, with `requests` especially fixing a thread-safety bug with 301 redirects handling. It seems to be working fine in my local development instance, so submitted for your consideration.