### PR TITLE
Treat src="//hostname/path" as insecure in SRI checks

### DIFF
--- a/httpobs/docs/scoring.md
+++ b/httpobs/docs/scoring.md
@@ -126,7 +126,7 @@ sri-not-implemented-<br>but-external-scripts-loaded-securely | Subresource Integ
 request-did-not-return-status-code-200 | Site did not return a status code of 200 (deprecated) | -5
 sri-implemented-<br>but-external-scripts-not-loaded-securely | Subresource Integrity (SRI) implemented, but external scripts are loaded over http | -20
 html-not-parsable | Claims to be html, but cannot be parsed | -20
-sri-not-implemented-<br>and-external-scripts-not-loaded-securely | Subresource Integrity (SRI) is not implemented, and external scripts are loaded over http | -50
+sri-not-implemented-<br>and-external-scripts-not-loaded-securely | Subresource Integrity (SRI) is not implemented, and external scripts are not loaded over https | -50
 <br>
 
 [X-Content-Type-Options](https://infosec.mozilla.org/Security/Guidelines/Web_Security#x-content-type-options) | Description | Modifier

--- a/httpobs/scanner/analyzer/content.py
+++ b/httpobs/scanner/analyzer/content.py
@@ -164,9 +164,6 @@ def subresource_integrity(reqs: dict, expectation='sri-implemented-and-external-
                 # Check to see if it's the same origin or second-level domain
                 if src.netloc == '' or samesld:
                     secureorigin = True
-                elif src.netloc != '' and '.' not in src.netloc:  # like localhost
-                    secureorigin = False
-                    scripts_on_foreign_origin = True
                 else:
                     secureorigin = False
                     scripts_on_foreign_origin = True

--- a/httpobs/scanner/grader/grade.py
+++ b/httpobs/scanner/grader/grade.py
@@ -319,7 +319,7 @@ SCORE_TABLE = {
         'modifier': -20,
     },
     'sri-not-implemented-and-external-scripts-not-loaded-securely': {
-        'description': 'Subresource Integrity (SRI) is not implemented, and external scripts are loaded over http',
+        'description': 'Subresource Integrity (SRI) not implemented, and external scripts are not loaded over https',
         'modifier': -50,
     },
 

--- a/httpobs/tests/unittests/files/test_content_sri_impl_external_http.html
+++ b/httpobs/tests/unittests/files/test_content_sri_impl_external_http.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <script src="/static/js/foo.js"></script>
+    <script src="http://fb.me/react-0.14.6.min.js"
+            integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
+            crossorigin="anonymous"></script>
+    <script src="https://fb.me/react-0.14.7.min.js"
+            integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
+            crossorigin="anonymous"></script>
+    <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_impl_external_https1.html
+++ b/httpobs/tests/unittests/files/test_content_sri_impl_external_https1.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <script src="/static/js/foo.js"></script>
+    <script src="https://fb.me/react-0.14.7.min.js"
+            integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
+            crossorigin="anonymous">
+    </script>
+  <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_impl_external_https2.html
+++ b/httpobs/tests/unittests/files/test_content_sri_impl_external_https2.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <script src="/static/js/foo.js"></script>
+    <script src="https://localhost/react-0.14.7.min.js"
+            integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
+            crossorigin="anonymous">
+    </script>
+  <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_impl_external_noproto.html
+++ b/httpobs/tests/unittests/files/test_content_sri_impl_external_noproto.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <script src="//fb.me/react-0.14.6.min.js"
+            integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
+            crossorigin="anonymous"></script>
+    <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_impl_sameorigin.html
+++ b/httpobs/tests/unittests/files/test_content_sri_impl_sameorigin.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <script src="/static/js/react-0.14.7.min.js"
+            integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
+            crossorigin="anonymous">
+    </script>
+  <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_no_scripts.html
+++ b/httpobs/tests/unittests/files/test_content_sri_no_scripts.html
@@ -1,0 +1,4 @@
+        <html>
+            <head></head>
+            <body></body>
+        </html>

--- a/httpobs/tests/unittests/files/test_content_sri_notimpl_external_http.html
+++ b/httpobs/tests/unittests/files/test_content_sri_notimpl_external_http.html
@@ -1,0 +1,7 @@
+<html>
+  <head>
+    <script src="/static/js/foo.js"></script>
+    <script src="http://fb.me/react-0.14.6.min.js"></script>
+    <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_notimpl_external_https.html
+++ b/httpobs/tests/unittests/files/test_content_sri_notimpl_external_https.html
@@ -1,0 +1,7 @@
+<html>
+  <head>
+    <script src="/static/js/foo.js"></script>
+    <script src="https://fb.me/react-0.14.7.min.js"></script>
+  <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_notimpl_external_noproto.html
+++ b/httpobs/tests/unittests/files/test_content_sri_notimpl_external_noproto.html
@@ -1,0 +1,7 @@
+<html>
+  <head>
+    <script src="/static/js/foo.js"></script>
+    <script src="//fb.me/react-0.14.6.min.js"></script>
+    <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_sameorigin1.html
+++ b/httpobs/tests/unittests/files/test_content_sri_sameorigin1.html
@@ -1,0 +1,6 @@
+<html>
+    <head>
+      <script src="/static/js/foo.js"></script>
+    </head>
+    <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_sameorigin2.html
+++ b/httpobs/tests/unittests/files/test_content_sri_sameorigin2.html
@@ -1,0 +1,6 @@
+<html>
+    <head>
+      <script src="https://www.mozilla.org/static/js/foo.js"></script>
+    </head>
+    <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_sameorigin3.html
+++ b/httpobs/tests/unittests/files/test_content_sri_sameorigin3.html
@@ -1,0 +1,6 @@
+<html>
+    <head>
+      <script src="//www.mozilla.org/static/js/foo.js"></script>
+    </head>
+    <body></body>
+</html>

--- a/httpobs/tests/unittests/test_content.py
+++ b/httpobs/tests/unittests/test_content.py
@@ -134,12 +134,7 @@ class TestSubResourceIntegrity(TestCase):
         self.reqs = None
 
     def test_no_scripts(self):
-        self.reqs['resources']['__path__'] = """
-        <html>
-            <head></head>
-            <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_no_scripts.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -169,14 +164,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertTrue(result['pass'])
 
     def test_same_origin(self):
-        self.reqs['resources']['__path__'] = """
-        <html>
-            <head>
-              <script src="/static/js/foo.js"></script>
-            </head>
-            <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_sameorigin1.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -184,14 +172,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertTrue(result['pass'])
 
         # On the same second-level domain
-        self.reqs['resources']['__path__'] = """
-        <html>
-            <head>
-              <script src="https://www.mozilla.org/static/js/foo.js"></script>
-            </head>
-            <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_sameorigin2.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -208,18 +189,7 @@ class TestSubResourceIntegrity(TestCase):
 
     def test_implemented_external_scripts_https(self):
         # load from a remote site
-        self.reqs['resources']['__path__'] = """
-        <html>
-          <head>
-            <script src="/static/js/foo.js"></script>
-            <script src="https://fb.me/react-0.14.7.min.js"
-                    integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
-                    crossorigin="anonymous">
-            </script>
-          <head>
-          <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_impl_external_https1.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -227,18 +197,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertTrue(result['pass'])
 
         # load from an intranet / localhost
-        self.reqs['resources']['__path__'] = """
-        <html>
-          <head>
-            <script src="/static/js/foo.js"></script>
-            <script src="https://localhost/react-0.14.7.min.js"
-                    integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
-                    crossorigin="anonymous">
-            </script>
-          <head>
-          <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_impl_external_https2.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -246,17 +205,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertTrue(result['pass'])
 
     def test_implemented_same_origin(self):
-        self.reqs['resources']['__path__'] = """
-        <html>
-          <head>
-            <script src="/static/js/react-0.14.7.min.js"
-                    integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
-                    crossorigin="anonymous">
-            </script>
-          <head>
-          <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_impl_sameorigin.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -264,15 +213,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertTrue(result['pass'])
 
     def test_not_implemented_external_scripts_https(self):
-        self.reqs['resources']['__path__'] = """
-        <html>
-          <head>
-            <script src="/static/js/foo.js"></script>
-            <script src="https://fb.me/react-0.14.7.min.js"></script>
-          <head>
-          <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_notimpl_external_https.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -280,20 +221,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertFalse(result['pass'])
 
     def test_implemented_external_scripts_http(self):
-        self.reqs['resources']['__path__'] = """
-        <html>
-          <head>
-            <script src="/static/js/foo.js"></script>
-            <script src="http://fb.me/react-0.14.6.min.js"
-                    integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
-                    crossorigin="anonymous"></script>
-            <script src="https://fb.me/react-0.14.7.min.js"
-                    integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
-                    crossorigin="anonymous"></script>
-            <head>
-          <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_impl_external_http.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -301,15 +229,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertFalse(result['pass'])
 
     def test_not_implemented_external_scripts_http(self):
-        self.reqs['resources']['__path__'] = """
-        <html>
-          <head>
-            <script src="/static/js/foo.js"></script>
-            <script src="http://fb.me/react-0.14.6.min.js"></script>
-            <head>
-          <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_notimpl_external_http.html')
 
         result = subresource_integrity(self.reqs)
 

--- a/httpobs/tests/unittests/test_content.py
+++ b/httpobs/tests/unittests/test_content.py
@@ -171,7 +171,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertEquals(result['result'], 'sri-not-implemented-but-all-scripts-loaded-from-secure-origin')
         self.assertTrue(result['pass'])
 
-        # On the same second-level domain
+        # On the same second-level domain, with https:// specified
         self.reqs = empty_requests('test_content_sri_sameorigin2.html')
 
         result = subresource_integrity(self.reqs)

--- a/httpobs/tests/unittests/test_content.py
+++ b/httpobs/tests/unittests/test_content.py
@@ -171,6 +171,14 @@ class TestSubResourceIntegrity(TestCase):
         self.assertEquals(result['result'], 'sri-not-implemented-but-all-scripts-loaded-from-secure-origin')
         self.assertTrue(result['pass'])
 
+        # On the same second-level domain, but without a protocol
+        self.reqs = empty_requests('test_content_sri_sameorigin3.html')
+
+        result = subresource_integrity(self.reqs)
+
+        self.assertEquals('sri-not-implemented-and-external-scripts-not-loaded-securely', result['result'])
+        self.assertFalse(result['pass'])
+
         # On the same second-level domain, with https:// specified
         self.reqs = empty_requests('test_content_sri_sameorigin2.html')
 
@@ -228,8 +236,24 @@ class TestSubResourceIntegrity(TestCase):
         self.assertEquals('sri-implemented-but-external-scripts-not-loaded-securely', result['result'])
         self.assertFalse(result['pass'])
 
+    def test_implemented_external_scripts_noproto(self):
+        self.reqs = empty_requests('test_content_sri_impl_external_noproto.html')
+
+        result = subresource_integrity(self.reqs)
+
+        self.assertEquals('sri-implemented-but-external-scripts-not-loaded-securely', result['result'])
+        self.assertFalse(result['pass'])
+
     def test_not_implemented_external_scripts_http(self):
         self.reqs = empty_requests('test_content_sri_notimpl_external_http.html')
+
+        result = subresource_integrity(self.reqs)
+
+        self.assertEquals('sri-not-implemented-and-external-scripts-not-loaded-securely', result['result'])
+        self.assertFalse(result['pass'])
+
+    def test_not_implemented_external_scripts_noproto(self):
+        self.reqs = empty_requests('test_content_sri_notimpl_external_noproto.html')
 
         result = subresource_integrity(self.reqs)
 

--- a/httpobs/tests/utils.py
+++ b/httpobs/tests/utils.py
@@ -11,6 +11,7 @@ def empty_requests(http_equiv_file=None) -> dict:
     req = {
         'hostname': 'http-observatory.security.mozilla.org',
         'resources': {
+            '__path__': None,
             '/': None,
             '/clientaccesspolicy.xml': None,
             '/contribute.json': None,
@@ -25,6 +26,16 @@ def empty_requests(http_equiv_file=None) -> dict:
         },
         'session': UserDict(),
     }
+
+    # Parse the HTML file for its own headers, if requested
+    if http_equiv_file:
+        __dirname = os.path.abspath(os.path.dirname(__file__))
+
+        with open(os.path.join(__dirname, 'unittests', 'files', http_equiv_file), 'r') as f:
+            html = f.read()
+
+        # Load the HTML file into the object for content tests.
+        req['resources']['__path__'] = html
 
     req['responses']['auto'].headers = {
         'Content-Type': 'text/html',
@@ -44,12 +55,7 @@ def empty_requests(http_equiv_file=None) -> dict:
 
     # Parse the HTML file for its own headers, if requested
     if http_equiv_file:
-        __dirname = os.path.abspath(os.path.dirname(__file__))
-
-        with open(os.path.join(__dirname, 'unittests', 'files', http_equiv_file), 'r') as f:
-            html = f.read()
-
-        req['responses']['auto'].http_equiv = parse_http_equiv_headers(html)
+        req['responses']['auto'].http_equiv = parse_http_equiv_headers(req['resources']['__path__'])
     else:
         req['responses']['auto'].http_equiv = {}
 


### PR DESCRIPTION
I tried to implement #324 by altering the existing SRI checks to mark `src="//hostname/path"` as an external script with an insecure scheme, copying the existing external-insecure -50 penalty to a new same-origin-insecure -50 penalty.

In addition to that new "same-origin" wording in the check name and description, I was careful to word the new description as `are not loaded over https` to be more explicit about this being a penalty for not saying `src="https://`; this varies from the other SRI wordings that say `are loaded over http`, which I might encourage altering to this form as well in a separate PR.

I'm not sure if -50 is the right score here, but any site using `<script src="//` could end up loading a script from an HTTP origin, which we do penalize as -50, so I went with that by default, but ensured that loading external scripts insecurely still takes precedence in the score priority.

This includes new tests and updates existing tests to ensure that `src="//` is detected as insecure in various scenarios.

I also removed a redundant `elif:` clause to avoid having to figure out what the intentions of the logic were vs. relative URIs, since it was an exact copy of the `else:` clause. The tests were unaffected by by that removal, prior to the test changes needed for this issue. If you'd like this as a separate PR, let me know.