### PR TITLE
Fix the link to Docker Toolbox. [#320]

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ httpobs-local-scan --http-port 8080 --https-port 8443 --path '/foo/bar' \
 ```
 
 ## Running a local scanner with Docker
-* Install [Docker Toolbox](https://www.docker.com/products/docker-toolbox) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+* Install [Docker Toolbox](https://docs.docker.com/toolbox/overview/) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 
 ```bash
 # Install the HTTP Observatory client and requests library


### PR DESCRIPTION
#320 observed that the link to Docker Toolbox no longer produced the expected result — Docker's website no longer makes it clear how to get the (slightly deprecated) Toolbox kit.

This updates the documentation URL to point to the current landing page for Toolbox, which clearly explains in the first page whether to use it or the newer tools. It's not a complete "rewrite this to not depend on Toolbox" patch, but it's just enough to help users succeed here.