### PR TITLE
Extract HTML content from test_content.py into files/test_*.html.

### DIFF
--- a/httpobs/tests/unittests/files/test_content_sri_impl_external_http.html
+++ b/httpobs/tests/unittests/files/test_content_sri_impl_external_http.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <script src="/static/js/foo.js"></script>
+    <script src="http://fb.me/react-0.14.6.min.js"
+            integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
+            crossorigin="anonymous"></script>
+    <script src="https://fb.me/react-0.14.7.min.js"
+            integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
+            crossorigin="anonymous"></script>
+    <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_impl_external_https1.html
+++ b/httpobs/tests/unittests/files/test_content_sri_impl_external_https1.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <script src="/static/js/foo.js"></script>
+    <script src="https://fb.me/react-0.14.7.min.js"
+            integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
+            crossorigin="anonymous">
+    </script>
+  <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_impl_external_https2.html
+++ b/httpobs/tests/unittests/files/test_content_sri_impl_external_https2.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <script src="/static/js/foo.js"></script>
+    <script src="https://localhost/react-0.14.7.min.js"
+            integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
+            crossorigin="anonymous">
+    </script>
+  <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_impl_sameorigin.html
+++ b/httpobs/tests/unittests/files/test_content_sri_impl_sameorigin.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <script src="/static/js/react-0.14.7.min.js"
+            integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
+            crossorigin="anonymous">
+    </script>
+  <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_no_scripts.html
+++ b/httpobs/tests/unittests/files/test_content_sri_no_scripts.html
@@ -1,0 +1,4 @@
+        <html>
+            <head></head>
+            <body></body>
+        </html>

--- a/httpobs/tests/unittests/files/test_content_sri_notimpl_external_http.html
+++ b/httpobs/tests/unittests/files/test_content_sri_notimpl_external_http.html
@@ -1,0 +1,7 @@
+<html>
+  <head>
+    <script src="/static/js/foo.js"></script>
+    <script src="http://fb.me/react-0.14.6.min.js"></script>
+    <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_notimpl_external_https.html
+++ b/httpobs/tests/unittests/files/test_content_sri_notimpl_external_https.html
@@ -1,0 +1,7 @@
+<html>
+  <head>
+    <script src="/static/js/foo.js"></script>
+    <script src="https://fb.me/react-0.14.7.min.js"></script>
+  <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_sameorigin1.html
+++ b/httpobs/tests/unittests/files/test_content_sri_sameorigin1.html
@@ -1,0 +1,6 @@
+<html>
+    <head>
+      <script src="/static/js/foo.js"></script>
+    </head>
+    <body></body>
+</html>

--- a/httpobs/tests/unittests/files/test_content_sri_sameorigin2.html
+++ b/httpobs/tests/unittests/files/test_content_sri_sameorigin2.html
@@ -1,0 +1,6 @@
+<html>
+    <head>
+      <script src="https://www.mozilla.org/static/js/foo.js"></script>
+    </head>
+    <body></body>
+</html>

--- a/httpobs/tests/unittests/test_content.py
+++ b/httpobs/tests/unittests/test_content.py
@@ -134,12 +134,7 @@ class TestSubResourceIntegrity(TestCase):
         self.reqs = None
 
     def test_no_scripts(self):
-        self.reqs['resources']['__path__'] = """
-        <html>
-            <head></head>
-            <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_no_scripts.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -169,14 +164,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertTrue(result['pass'])
 
     def test_same_origin(self):
-        self.reqs['resources']['__path__'] = """
-        <html>
-            <head>
-              <script src="/static/js/foo.js"></script>
-            </head>
-            <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_sameorigin1.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -184,14 +172,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertTrue(result['pass'])
 
         # On the same second-level domain
-        self.reqs['resources']['__path__'] = """
-        <html>
-            <head>
-              <script src="https://www.mozilla.org/static/js/foo.js"></script>
-            </head>
-            <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_sameorigin2.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -208,18 +189,7 @@ class TestSubResourceIntegrity(TestCase):
 
     def test_implemented_external_scripts_https(self):
         # load from a remote site
-        self.reqs['resources']['__path__'] = """
-        <html>
-          <head>
-            <script src="/static/js/foo.js"></script>
-            <script src="https://fb.me/react-0.14.7.min.js"
-                    integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
-                    crossorigin="anonymous">
-            </script>
-          <head>
-          <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_impl_external_https1.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -227,18 +197,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertTrue(result['pass'])
 
         # load from an intranet / localhost
-        self.reqs['resources']['__path__'] = """
-        <html>
-          <head>
-            <script src="/static/js/foo.js"></script>
-            <script src="https://localhost/react-0.14.7.min.js"
-                    integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
-                    crossorigin="anonymous">
-            </script>
-          <head>
-          <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_impl_external_https2.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -246,17 +205,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertTrue(result['pass'])
 
     def test_implemented_same_origin(self):
-        self.reqs['resources']['__path__'] = """
-        <html>
-          <head>
-            <script src="/static/js/react-0.14.7.min.js"
-                    integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
-                    crossorigin="anonymous">
-            </script>
-          <head>
-          <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_impl_sameorigin.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -264,15 +213,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertTrue(result['pass'])
 
     def test_not_implemented_external_scripts_https(self):
-        self.reqs['resources']['__path__'] = """
-        <html>
-          <head>
-            <script src="/static/js/foo.js"></script>
-            <script src="https://fb.me/react-0.14.7.min.js"></script>
-          <head>
-          <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_notimpl_external_https.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -280,20 +221,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertFalse(result['pass'])
 
     def test_implemented_external_scripts_http(self):
-        self.reqs['resources']['__path__'] = """
-        <html>
-          <head>
-            <script src="/static/js/foo.js"></script>
-            <script src="http://fb.me/react-0.14.6.min.js"
-                    integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
-                    crossorigin="anonymous"></script>
-            <script src="https://fb.me/react-0.14.7.min.js"
-                    integrity="sha384-zTm/dblzLXQNp3CgY+hfaC/WJ6h4XtNrePh2CW2+rO9GPuNiPb9jmthvAL+oI/dQ"
-                    crossorigin="anonymous"></script>
-            <head>
-          <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_impl_external_http.html')
 
         result = subresource_integrity(self.reqs)
 
@@ -301,15 +229,7 @@ class TestSubResourceIntegrity(TestCase):
         self.assertFalse(result['pass'])
 
     def test_not_implemented_external_scripts_http(self):
-        self.reqs['resources']['__path__'] = """
-        <html>
-          <head>
-            <script src="/static/js/foo.js"></script>
-            <script src="http://fb.me/react-0.14.6.min.js"></script>
-            <head>
-          <body></body>
-        </html>
-        """
+        self.reqs = empty_requests('test_content_sri_notimpl_external_http.html')
 
         result = subresource_integrity(self.reqs)
 

--- a/httpobs/tests/utils.py
+++ b/httpobs/tests/utils.py
@@ -11,6 +11,7 @@ def empty_requests(http_equiv_file=None) -> dict:
     req = {
         'hostname': 'http-observatory.security.mozilla.org',
         'resources': {
+            '__path__': None,
             '/': None,
             '/clientaccesspolicy.xml': None,
             '/contribute.json': None,
@@ -25,6 +26,16 @@ def empty_requests(http_equiv_file=None) -> dict:
         },
         'session': UserDict(),
     }
+
+    # Parse the HTML file for its own headers, if requested
+    if http_equiv_file:
+        __dirname = os.path.abspath(os.path.dirname(__file__))
+
+        with open(os.path.join(__dirname, 'unittests', 'files', http_equiv_file), 'r') as f:
+            html = f.read()
+
+        # Load the HTML file into the object for content tests.
+        req['resources']['__path__'] = html
 
     req['responses']['auto'].headers = {
         'Content-Type': 'text/html',
@@ -44,12 +55,7 @@ def empty_requests(http_equiv_file=None) -> dict:
 
     # Parse the HTML file for its own headers, if requested
     if http_equiv_file:
-        __dirname = os.path.abspath(os.path.dirname(__file__))
-
-        with open(os.path.join(__dirname, 'unittests', 'files', http_equiv_file), 'r') as f:
-            html = f.read()
-
-        req['responses']['auto'].http_equiv = parse_http_equiv_headers(html)
+        req['responses']['auto'].http_equiv = parse_http_equiv_headers(req['resources']['__path__'])
     else:
         req['responses']['auto'].http_equiv = {}
 


### PR DESCRIPTION
This will fail tests immediately, as for unknown reasons the `empty_resources()` function does not seem to be producing the result @april expected. I don't quite know where to begin diagnosing this, so submitting the PR for assistance since this refactor is now blocking #327.