### PR TITLE
Make X-XSS-Protection header check stricter

### DIFF
--- a/httpobs/tests/unittests/test_headers.py
+++ b/httpobs/tests/unittests/test_headers.py
@@ -1142,6 +1142,22 @@ class TestXXSSProtection(TestCase):
         self.assertEquals('x-xss-protection-header-invalid', result['result'])
         self.assertFalse(result['pass'])
 
+    def test_header_invalid_syntax(self):
+        self.reqs['responses']['auto'].headers['X-XSS-Protection'] = '1 mode=block'
+
+        result = x_xss_protection(self.reqs)
+
+        self.assertEquals('x-xss-protection-header-invalid', result['result'])
+        self.assertFalse(result['pass'])
+
+    def test_header_invalid_this_one_goes_to_eleven(self):
+        self.reqs['responses']['auto'].headers['X-XSS-Protection'] = '11'
+
+        result = x_xss_protection(self.reqs)
+
+        self.assertEquals('x-xss-protection-header-invalid', result['result'])
+        self.assertFalse(result['pass'])
+
     def test_disabled(self):
         self.reqs['responses']['auto'].headers['X-XSS-Protection'] = '0'
 


### PR DESCRIPTION
Webkit doesn't just take the first character unless it is 0
See https://github.com/WebKit/webkit/blob/f43689c3ed50cd00bf76d5731983046b988e6efa/Source/WebCore/platform/network/HTTPParsers.cpp#L401

Thus, a number of additional failure modes are still possible,
including:

`1 mode=block` (and even if browsers did parse 1, this is probably not
the user's intent)
Example of failure in securityheaders.io vs observatory:
https://securityheaders.io/?q=https%3A%2F%2Fstore.revolutionparts.com%2F&followRedirects=on
https://observatory.mozilla.org/analyze/store.revolutionparts.com

`11` (Hopefully never observed in the wild, but....)

This still maintains `01` as disabled, which probably is not intended by
the source, but is inline with webkit