### PR TITLE
Treat insecure __cfduid cookies as insecure

### DIFF
--- a/httpobs/scanner/analyzer/headers.py
+++ b/httpobs/scanner/analyzer/headers.py
@@ -4,13 +4,9 @@ from httpobs.scanner.analyzer.decorators import scored_test
 from httpobs.scanner.analyzer.utils import is_hpkp_preloaded, is_hsts_preloaded, only_if_worse
 
 
-# Ignore the CloudFlare __cfduid tracking cookies. They *are* actually bad, but it is out of a site's
-# control.  See https://github.com/mozilla/http-observatory/issues/121 for additional details. Hopefully
-# this will eventually be fixed on CloudFlare's end.
-
-# Also ignore the Heroku sticky session cookie, see:
+# Ignore the Heroku sticky session cookie, see:
 # https://github.com/mozilla/http-observatory/issues/282
-COOKIES_TO_DELETE = ['__cfduid', 'heroku-session-affinity']
+COOKIES_TO_DELETE = ['heroku-session-affinity']
 
 # CSP settings
 SHORTEST_DIRECTIVE = 'img-src'

--- a/httpobs/tests/unittests/test_headers.py
+++ b/httpobs/tests/unittests/test_headers.py
@@ -354,26 +354,6 @@ class TestCookies(TestCase):
                         value='bar')
         self.reqs['session'].cookies.set_cookie(cookie)
 
-        # See: https://github.com/mozilla/http-observatory/issues/121 for the __cfduid insanity
-        cookie = Cookie(name='__cfduid',
-                        comment=None,
-                        comment_url=None,
-                        discard=False,
-                        domain='mozilla.com',
-                        domain_initial_dot=False,
-                        domain_specified='mozilla.com',
-                        expires=None,
-                        path='/',
-                        path_specified='/',
-                        port=443,
-                        port_specified=443,
-                        rest={},
-                        rfc2109=False,
-                        secure=False,
-                        version=1,
-                        value='bar')
-        self.reqs['session'].cookies.set_cookie(cookie)
-
         # See: https://github.com/mozilla/http-observatory/issues/282 for the heroku-session-affinity insanity
         cookie = Cookie(name='heroku-session-affinity',
                         comment=None,
@@ -645,6 +625,26 @@ class TestCookies(TestCase):
                         port_specified=443,
                         rfc2109=False,
                         rest={},
+                        secure=False,
+                        version=1,
+                        value='bar')
+        self.reqs['session'].cookies.set_cookie(cookie)
+
+        # See: https://github.com/mozilla/http-observatory/issues/121 for the __cfduid insanity
+        cookie = Cookie(name='__cfduid',
+                        comment=None,
+                        comment_url=None,
+                        discard=False,
+                        domain='mozilla.com',
+                        domain_initial_dot=False,
+                        domain_specified='mozilla.com',
+                        expires=None,
+                        path='/',
+                        path_specified='/',
+                        port=443,
+                        port_specified=443,
+                        rest={},
+                        rfc2109=False,
                         secure=False,
                         version=1,
                         value='bar')


### PR DESCRIPTION
Currently, CloudFlare's insecure cookies are ignored.
This commit removes this special treatment.

Fixes #202.

---

Sorry for being obnoxious in discussions, don't want to burn anyone out. Here is the fix to the issue. Tests have been updated, not sure it's entirely correct. Maybe it belongs into the "insecure, but HSTS" category.