### PR TITLE
Update __init__.py

### DIFF
--- a/httpobs/scanner/__init__.py
+++ b/httpobs/scanner/__init__.py
@@ -18,7 +18,7 @@ __all__ = [
     'STATE_ABORTED',
     'STATE_FAILED',
     'STATE_FINISHED',
-    'STATE_PENDING,'
+    'STATE_PENDING',
     'STATE_RUNNING',
     'STATE_STARTING',
 ]


### PR DESCRIPTION
fix typo that transposed `,` and `'`