### PR TITLE
HPKP is downgraded, update scoring to report presence/absence/preload

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ pip3 install --upgrade -r requirements.txt
          path='/foo/bar',            # don't scan /, instead scan /foo/bar
          cookies={'foo': 'bar'},     # set the "foo" cookie to "bar"
          headers={'X-Foo': 'bar'},   # send an X-Foo: bar HTTP header
-         verify=False)               # treat self-signed certs as valid for tests like HSTS/HPKP
+         verify=False)               # treat self-signed certs as valid for tests like HSTS
 ```
 
 ### The same, but with the local CLI

--- a/httpobs/docs/api.md
+++ b/httpobs/docs/api.md
@@ -395,7 +395,7 @@ Example:
     "score_modifier": 0
   },
   "public-key-pinning": {
-    "expectation": "hpkp-not-implemented",
+    "expectation": "hpkp-not-present",
     "name": "public-key-pinning",
     "output": {
       "data": null,
@@ -405,8 +405,8 @@ Example:
       "preloaded": false
     },
     "pass": true,
-    "result": "hpkp-not-implemented",
-    "score_description": "HTTP Public Key Pinning (HPKP) header not implemented",
+    "result": "hpkp-not-present",
+    "score_description": "Deprecated HTTP Public Key Pinning (HPKP) header is not present",
     "score_modifier": 0
   },
   "redirection": {

--- a/httpobs/docs/scoring.md
+++ b/httpobs/docs/scoring.md
@@ -75,12 +75,8 @@ csp-header-invalid | Content Security Policy (CSP) header cannot be parsed succe
 [HTTP Public Key Pinning](https://infosec.mozilla.org/guidelines/web_security#http-public-key-pinning) | Description | Modifier
 --- | --- | :---:
 hpkp-preloaded | Preloaded via the HTTP Public Key Pinning (HPKP) preloading process | 0
-hpkp-implemented-<br>max-age-at-least-fifteen-days | HTTP Public Key Pinning (HPKP) header set to a minimum of 15 days (1296000) | 0
-hpkp-implemented-<br>max-age-less-than-fifteen-days | HTTP Public Key Pinning (HPKP) header set to less than 15 days (1296000) | 0
-hpkp-not-implemented | HTTP Public Key Pinning (HPKP) header not implemented | 0
-hpkp-invalid-cert | HTTP Public Key Pinning (HPKP) header cannot be set, as site contains an invalid certificate chain | 0
-hpkp-not-implemented-no-https | HTTP Public Key Pinning (HPKP) header can't be implemented without https | 0
-hpkp-header-invalid | HTTP Public Key Pinning (HPKP) header cannot be recognized | -5
+hpkp-not-present | Deprecated HTTP Public Key Pinning (HPKP) header is not present | 0
+hpkp-is-deprecated | HTTP Public Key Pinning (HPKP) header is present, but HPKP is deprecated and no longer recommended | 0
 <br>
 
 [HTTP Strict Transport Security](https://infosec.mozilla.org/guidelines/web_security#http-strict-transport-security) | Description | Modifier

--- a/httpobs/scanner/grader/grade.py
+++ b/httpobs/scanner/grader/grade.py
@@ -170,34 +170,18 @@ SCORE_TABLE = {
         'modifier': -50,
     },
 
-    # Public Key Pinning
+    # Public Key Pinning (deprecated)
     'hpkp-preloaded': {
         'description': 'Preloaded via the HTTP Public Key Pinning (HPKP) preloading process',
         'modifier': 0,
     },
-    'hpkp-implemented-max-age-at-least-fifteen-days': {
-        'description': 'HTTP Public Key Pinning (HPKP) header set to a minimum of 15 days (1296000)',
+    'hpkp-not-present': {
+        'description': 'Deprecated HTTP Public Key Pinning (HPKP) header is not present',
         'modifier': 0,
     },
-    'hpkp-implemented-max-age-less-than-fifteen-days': {
-        'description': 'HTTP Public Key Pinning (HPKP) header set to less than 15 days (1296000)',
-        'modifier': 0,
-    },
-    'hpkp-not-implemented': {
-        'description': 'HTTP Public Key Pinning (HPKP) header not implemented',
-        'modifier': 0,
-    },
-    'hpkp-not-implemented-no-https': {
-        'description': 'HTTP Public Key Pinning (HPKP) header can\'t be implemented without HTTPS',
-        'modifier': 0,
-    },
-    'hpkp-invalid-cert': {
-        'description': ('HTTP Public Key Pinning (HPKP) header cannot be set, '
-                        'as site contains an invalid certificate chain'),
-        'modifier': 0,
-    },
-    'hpkp-header-invalid': {
-        'description': 'HTTP Public Key Pinning (HPKP) header cannot be recognized',
+    'hpkp-is-deprecated': {
+        'description': ('HTTP Public Key Pinning (HPKP) header is present, but HPKP is deprecated '
+                        'and no longer recommended'),
         'modifier': -5,
     },
 

--- a/httpobs/scanner/local.py
+++ b/httpobs/scanner/local.py
@@ -20,7 +20,7 @@ def scan(hostname, **kwargs):
         path (str): path to scan, instead of "/"
         verify (bool): whether to enable or disable certificate verification,
             enabled by default. This can allow tested sites to pass the HSTS
-            and HPKP tests, even with self-signed certificates.
+            tests, even with self-signed certificates.
 
         cookies (dict): Cookies sent to the system being scanned. Matches the
             requests cookie dict.

--- a/httpobs/scripts/httpobs-local-scan
+++ b/httpobs/scripts/httpobs-local-scan
@@ -27,7 +27,7 @@ if __name__ == "__main__":
                         type=str)
     parser.add_argument('--no-verify',
                         action='store_true',
-                        help='disable certificate verification in the HSTS/HPKP tests')
+                        help='disable certificate verification in the HSTS tests')
     parser.add_argument('--cookies',
                         default=argparse.SUPPRESS,
                         help='cookies to send in scan (json formatted)',

--- a/httpobs/tests/unittests/test_headers.py
+++ b/httpobs/tests/unittests/test_headers.py
@@ -745,99 +745,21 @@ class TestPublicKeyPinning(TestCase):
     def test_missing(self):
         result = public_key_pinning(self.reqs)
 
-        self.assertEquals('hpkp-not-implemented', result['result'])
+        self.assertEquals('hpkp-not-present', result['result'])
         self.assertTrue(result['pass'])
 
-    def test_header_invalid(self):
-        # No pins
-        self.reqs['responses']['https'].headers['Public-Key-Pins'] = 'max-age=15768000; includeSubDomains; preload'
+    def test_present(self):
+        # the hpkp deprecation checks no longer distinguish http/https
+        self.reqs['responses']['auto'].headers['Public-Key-Pins'] = 'present'
 
         result = public_key_pinning(self.reqs)
 
-        self.assertEquals('hpkp-header-invalid', result['result'])
-        self.assertEquals(0, result['numPins'])
-        self.assertFalse(result['pass'])
-
-        # No max-age
-        self.reqs['responses']['https'].headers['Public-Key-Pins'] = (
-            'pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g="; '
-            'pin-sha256="LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ="; '
-            'report-uri="http://example.com/pkp-report"')
-        result = public_key_pinning(self.reqs)
-
-        self.assertEquals('hpkp-header-invalid', result['result'])
-        self.assertEquals(None, result['max-age'])
-        self.assertEquals(2, result['numPins'])
-        self.assertFalse(result['pass'])
-
-        # Not enough pins
-        self.reqs['responses']['https'].headers['Public-Key-Pins'] = (
-            'max-age=15768000; '
-            'pin-sha256="LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ="; '
-            'report-uri="http://example.com/pkp-report"')
-
-        result = public_key_pinning(self.reqs)
-
-        self.assertEquals('hpkp-header-invalid', result['result'])
-        self.assertEquals(15768000, result['max-age'])
-        self.assertEquals(1, result['numPins'])
-        self.assertFalse(result['pass'])
-
-    def test_no_https(self):
-        self.reqs['responses']['auto'].headers['Public-Key-Pins'] = 'max-age=15768000'
-        self.reqs['responses']['http'].headers['Public-Key-Pins'] = 'max-age=15768000'
-        self.reqs['responses']['https'] = None
-
-        result = public_key_pinning(self.reqs)
-
-        self.assertEquals('hpkp-not-implemented-no-https', result['result'])
-        self.assertTrue(result['pass'])
-
-    def test_invalid_cert(self):
-        self.reqs['responses']['https'].headers['Public-Key-Pins'] = (
-            'max-age=15768000; '
-            'includeSubDomains; '
-            'pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g="; '
-            'pin-sha256="LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ="; '
-            'report-uri="http://example.com/pkp-report"')
-        self.reqs['responses']['https'].verified = False
-
-        result = public_key_pinning(self.reqs)
-
-        self.assertEquals('hpkp-invalid-cert', result['result'])
-        self.assertTrue(result['pass'])
-
-    def test_max_age_too_low(self):
-        self.reqs['responses']['https'].headers['Public-Key-Pins'] = (
-            'max-age=86400; '
-            'pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g="; '
-            'pin-sha256="LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ="; '
-            'report-uri="http://example.com/pkp-report"')
-
-        result = public_key_pinning(self.reqs)
-
-        self.assertEquals('hpkp-implemented-max-age-less-than-fifteen-days', result['result'])
-        self.assertTrue(result['pass'])
-
-    def test_implemented(self):
-        self.reqs['responses']['https'].headers['Public-Key-Pins'] = (
-            'max-age=15768000; '
-            'includeSubDomains; '
-            'pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g="; '
-            'pin-sha256="LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ="; '
-            'report-uri="http://example.com/pkp-report"')
-
-        result = public_key_pinning(self.reqs)
-
-        self.assertEquals('hpkp-implemented-max-age-at-least-fifteen-days', result['result'])
-        self.assertEquals(15768000, result['max-age'])
-        self.assertEquals(15768000, result['max-age'])
-        self.assertTrue(result['includeSubDomains'])
+        self.assertEquals('hpkp-is-deprecated', result['result'])
         self.assertTrue(result['pass'])
 
     def test_preloaded(self):
         # apis.google.com has regular includeSubDomains
-        self.reqs['responses']['https'].url = 'https://apis.google.com/'
+        self.reqs['responses']['auto'].url = 'https://apis.google.com/'
 
         result = public_key_pinning(self.reqs)
 
@@ -845,7 +767,7 @@ class TestPublicKeyPinning(TestCase):
         self.assertTrue(result['includeSubDomains'])
         self.assertTrue(result['pass'])
         self.assertTrue(result['preloaded'])
-        self.reqs['responses']['https'].url = 'https://foo.apis.google.com'
+        self.reqs['responses']['auto'].url = 'https://foo.apis.google.com'
 
         result = public_key_pinning(self.reqs)
 
@@ -855,7 +777,7 @@ class TestPublicKeyPinning(TestCase):
         self.assertTrue(result['preloaded'])
 
         # Dropbox Static uses include_subdomains_for_pinning
-        self.reqs['responses']['https'].url = 'https://foo.dropboxstatic.com/'
+        self.reqs['responses']['auto'].url = 'https://foo.dropboxstatic.com/'
 
         result = public_key_pinning(self.reqs)
 


### PR DESCRIPTION
This removes most HPKP scoring functionality. The HPKP preload checks are left in place for now, but all other checks are reduced to 'header is present' or 'header is absent', both scored 0 and the former with a clear deprecation warning. Closes #422, but should be released in coordination with mozilla/http-observatory-website#172 and mozilla/infosec.mozilla.org#107.