### PR TITLE
Update API definition & availability

### DIFF
--- a/httpobs/docs/api.md
+++ b/httpobs/docs/api.md
@@ -81,7 +81,7 @@ Examples:
 
 ### Retrieve host's scan history
 
-Retrieve the ten most recent scans that fall within a given score range. Maps hostnames to scores, returning a [host history object](#host-history).
+This returns all public scans made to a website. Including its grade, and score. Returning a [host history object](#host-history).
 
 **API Call:** `getHostHistory`<br>
 **API Method:** `GET`
@@ -103,7 +103,7 @@ This returns each possible grade in the HTTP Observatory, as well as how many sc
 Example:
 * `/api/v1/getGradeDistribution`
 
-### Retrieve scanner states
+### ~~Retrieve scanner states~~ `DEPRECATED`
 
 This returns the state of the scanner. It can be useful for determining how busy the HTTP Observatory is. Returns a [Scanner state object](#scanner-state).
 


### PR DESCRIPTION
A cleaner PR for https://github.com/mozilla/http-observatory/pull/445

As a fellow user of the API, and as a reader of this document, just found some inaccuracy since it last updated.

1. There's a deprecated API route from `httpobs/website/api.py` [L150-L56](https://github.com/mozilla/http-observatory/blob/92641c6b8d982fb37088a7d7778c74af2776da5a/httpobs/website/api.py#L150-L156), confirmed via the comment provided. And it's responsible for `Retrieve scanner states` endpoint. Just want to add a deprecated label to it, and strikethrough, for users not waste their time waiting for a GATEWAY_TIMEOUT anymore. 😄 

2. Updated definition of `Retrieve host's scan history`, since it's the same as `Retrieve recent scans`, however, the object linked is different(no probs). Just updated its definition based on its response and behavior.