### PR TITLE
Update the nose tests to run on Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.5', '3.7' ]
+        python-version: [ '3.6', '3.7' ]
     env:
       HTTPOBS_BROKER_URL: fakebrokerurl
       HTTPOBS_DATABASE_HOST: fakehost


### PR DESCRIPTION
We run python 3.6 in production. The newest version of python requests no longer supports 3.5