### PR TITLE
Increment release version to 0.9.3

### DIFF
--- a/httpobs/__init__.py
+++ b/httpobs/__init__.py
@@ -1,2 +1,2 @@
 SOURCE_URL = 'https://github.com/mozilla/http-observatory'
-VERSION = '0.9.2'
+VERSION = '0.9.3'


### PR DESCRIPTION
This maps to the now pypi released version : https://pypi.org/project/httpobs/0.9.3/