### PR TITLE
Give points for not having cookies

### DIFF
--- a/httpobs/docs/scoring.md
+++ b/httpobs/docs/scoring.md
@@ -39,7 +39,7 @@ contribute-json-invalid-json | Contribute.json file cannot be parsed | -10
 [Cookies](https://infosec.mozilla.org/guidelines/web_security#cookies) | Description | Modifier
 --- | --- | :---:
 cookies-secure-with-httponly-sessions-and-samesite | All cookies use the Secure flag, session cookies use the HttpOnly flag, and cross-origin restrictions are in place via the SameSite flag | 5
-cookies-not-found | No cookies detected | 0
+cookies-not-found | No cookies detected | 5
 cookies-secure-with-httponly-sessions | All cookies use the `Secure` flag and all session cookies use the `HttpOnly` flag | 0
 cookies-without-secure-flag-<br>but-protected-by-hsts | Cookies set without using the `Secure` flag, but transmission over HTTP prevented by HSTS | -5
 cookies-session-without-secure-flag-<br>but-protected-by-hsts | Session cookie set without the `Secure` flag, but transmission over HTTP prevented by HSTS | -10

--- a/httpobs/scanner/grader/grade.py
+++ b/httpobs/scanner/grader/grade.py
@@ -113,12 +113,12 @@ SCORE_TABLE = {
         'modifier': 5,
 
     },
-    'cookies-secure-with-httponly-sessions': {
-        'description': 'All cookies use the Secure flag and all session cookies use the HttpOnly flag',
-        'modifier': 0,
-    },
     'cookies-not-found': {
         'description': 'No cookies detected',
+        'modifier': 5,
+    },
+    'cookies-secure-with-httponly-sessions': {
+        'description': 'All cookies use the Secure flag and all session cookies use the HttpOnly flag',
         'modifier': 0,
     },
     'cookies-without-secure-flag-but-protected-by-hsts': {


### PR DESCRIPTION
HTTP Observatory shouldn't encourage web developers to add cookies to their website simply to get more points. Fixes #449.