### PR TITLE
Add display parameter to getScanResults (API)

### DIFF
--- a/httpobs/__init__.py
+++ b/httpobs/__init__.py
@@ -1,2 +1,2 @@
 SOURCE_URL = 'https://github.com/mozilla/http-observatory'
-VERSION = '0.9.3'
+VERSION = '0.9.4'

--- a/httpobs/docs/api.md
+++ b/httpobs/docs/api.md
@@ -57,6 +57,7 @@ Each scan consists of a variety of subtests, including Content Security Policy, 
 Parameters:
 
 * `scan` scan_id number from the [scan object](#scan)
+* `display` format of output, allowed values: `object` (default), `array`
 
 Example:
 

--- a/httpobs/website/api.py
+++ b/httpobs/website/api.py
@@ -221,6 +221,7 @@ def api_get_scanner_stats():
 @sanitized_api_response
 def api_get_scan_results():
     scan_id = request.args.get('scan')
+    display = request.args.get('display', 'object').lower()
 
     if not scan_id:
         return {'error': 'scan-not-found'}
@@ -237,9 +238,14 @@ def api_get_scan_results():
 
     # Get all the test results for the given scan id
     tests = dict(database.select_test_results(scan_id))
+    iterator = tests
+
+    if display == 'array':
+        tests = list(tests.values())
+        iterator = range(0, len(tests))
 
     # For each test, get the test score description and add that in
-    for test in tests:
+    for test in iterator:
         tests[test]['score_description'] = get_score_description(tests[test]['result'])
 
     return tests

--- a/httpobs/website/decorators.py
+++ b/httpobs/website/decorators.py
@@ -62,7 +62,9 @@ def sanitized_api_response(fn):
                                   'score_description', 'score_modifier')
 
         # Convert it to a dict (in case it's a DictRow)
-        output = dict(output)
+        is_list = type(output) == list
+        if not is_list:
+            output = dict(output)
 
         if 'tests_quantity' in output:  # autodetect that it's a scan
             # Rename 'id' to 'result_id':
@@ -75,8 +77,8 @@ def sanitized_api_response(fn):
             # Delete any other things that might have made their way into the results
             output = {k: output[k] for k in SCAN_VALID_KEYS if k in output}
 
-        elif 'content-security-policy' in output:  # autodetect that it's a test result
-            for test in output:
+        elif 'content-security-policy' in output or is_list:  # autodetect that it's a test result
+            for test in (range(0, len(output)) if is_list else output):
                 # Delete unnecessary keys
                 output[test] = {k: output[test][k] for k in output[test] if k in TEST_RESULT_VALID_KEYS}
 


### PR DESCRIPTION
The actual output of `/api/v1/getScanResults` is an object, where value contains next object with test result properties. These properties contain a `name` key, which value is identical to name of superior's object key. 

Example (simplified for clarity):
```json
{
    "content-security-policy": {
        "name": "content-security-policy"
    }
}
``` 

For my use case, I found an alternative keeping only the value objects and passing them into array. The name remained only in the properties object. Of course, I don't want to break current code, so this option is available as an optional parameter.

Example (simplified for clarity):
```json
[
    {
        "name": "content-security-policy"
    }
]
``` 

The initiative comes from no availability to iterate through object keys in programming language that I currently use.