### PR TITLE
Add ability to process multiple CSP policies

### DIFF
--- a/httpobs/scanner/retriever/__init__.py
+++ b/httpobs/scanner/retriever/__init__.py
@@ -1,3 +1,7 @@
 from .retriever import retrieve_all
+from .utils import get_duplicate_header_values
 
-__all__ = ['retrieve_all']
+__all__ = [
+    'get_duplicate_header_values',
+    'retrieve_all',
+]

--- a/httpobs/scanner/retriever/retriever.py
+++ b/httpobs/scanner/retriever/retriever.py
@@ -125,15 +125,6 @@ def __get_page_text(response: requests.Response, force: bool = False) -> str:
         return None
 
 
-# According to RFC 2616, when two headers with the same name are sent then user agents are technically
-# supposed to combine them with a comma. However, some things (like CSP) are not treated that way,
-# and instead treated as if the policy has been sent multiple times. This checks to see if a header
-# appears multiple times, and, if so, returns a single header joined with `joiner`. `,` is the default
-# joiner, same as RFC 2616.
-def __get_raw_header(response, header, joiner: str = ", ") -> str:
-    return joiner.join([v for k, v in response.raw.headers.items() if k.lower().strip() == header.lower()])
-
-
 def retrieve_all(hostname, **kwargs):
     kwargs['cookies'] = kwargs.get('cookies', {})   # HTTP cookies to send, instead of from the database
     kwargs['headers'] = kwargs.get('headers', {})   # HTTP headers to send, instead of from the database
@@ -208,9 +199,10 @@ def retrieve_all(hostname, **kwargs):
     # Content Security Policy can be delivered as multiple headers, so we'll try to combine them
     # with a semi-colon if necessary
     if ',' in retrievals['responses']['auto'].headers.get('Content-Security-Policy', ''):
-        retrievals['responses']['auto'].headers['Content-Security-Policy'] = \
-            __get_raw_header(retrievals['responses']['auto'],
-                             'Content-Security-Policy',
-                             '; ')
+        pass
+        # retrievals['responses']['auto'].headers['Content-Security-Policy'] = \
+        #     __get_raw_header(retrievals['responses']['auto'],
+        #                      'Content-Security-Policy',
+        #                      '; ')
 
     return retrievals

--- a/httpobs/scanner/retriever/retriever.py
+++ b/httpobs/scanner/retriever/retriever.py
@@ -196,13 +196,4 @@ def retrieve_all(hostname, **kwargs):
     else:
         retrievals['responses']['auto'].http_equiv = {}
 
-    # Content Security Policy can be delivered as multiple headers, so we'll try to combine them
-    # with a semi-colon if necessary
-    if ',' in retrievals['responses']['auto'].headers.get('Content-Security-Policy', ''):
-        pass
-        # retrievals['responses']['auto'].headers['Content-Security-Policy'] = \
-        #     __get_raw_header(retrievals['responses']['auto'],
-        #                      'Content-Security-Policy',
-        #                      '; ')
-
     return retrievals

--- a/httpobs/scanner/retriever/utils.py
+++ b/httpobs/scanner/retriever/utils.py
@@ -1,0 +1,15 @@
+def get_duplicate_header_values(response, header) -> list:
+    # According to RFC 2616, when two headers with the same name are sent then user agents are technically
+    # supposed to combine them with a comma. However, some things (like CSP) are not treated that way,
+    # and instead treated as if the policy has been sent multiple times. This allows code to retrieve
+    # a list of every header instance.
+    """
+    Args:
+        response: the raw response object from requests
+        header: the header that one is looking for (e.g. Content-Security-Policy)
+
+    Returns:
+        all instances of that header, as a list
+
+    """
+    return [v for k, v in response.raw.headers.items() if k.lower().strip() == header.lower()]

--- a/httpobs/scanner/utils.py
+++ b/httpobs/scanner/utils.py
@@ -14,7 +14,9 @@ HSTS_URL = 'https://raw.githubusercontent.com/chromium/chromium/main/net/http/tr
 
 
 def parse_http_equiv_headers(html: str) -> CaseInsensitiveDict:
-    http_equiv_headers = CaseInsensitiveDict()
+    http_equiv_headers = CaseInsensitiveDict({
+        'Content-Security-Policy': [],
+    })
 
     # Try to parse the HTML
     try:
@@ -31,11 +33,8 @@ def parse_http_equiv_headers(html: str) -> CaseInsensitiveDict:
             # See issue: https://github.com/mozilla/http-observatory/issues/266
             # Note that this is so far only done for CSP and not for other types
             # of http-equiv
-            if (meta.get('http-equiv', '').lower().strip() == 'content-security-policy' and
-               'Content-Security-Policy' in http_equiv_headers):
-                http_equiv_headers['Content-Security-Policy'] += '; ' + meta.get('content')
-            else:
-                http_equiv_headers[meta.get('http-equiv')] = meta.get('content')
+            if meta.get('http-equiv', '').lower().strip() == 'content-security-policy':
+                http_equiv_headers['Content-Security-Policy'].append(meta.get('content'))
 
         # Technically not HTTP Equiv, but I'm treating it that way
         elif meta.get('name', '').lower().strip() == 'referrer' and meta.has_attr('content'):

--- a/httpobs/tests/unittests/files/test_parse_http_equiv_headers_csp2.html
+++ b/httpobs/tests/unittests/files/test_parse_http_equiv_headers_csp2.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src https:">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/httpobs/tests/unittests/test_csp_parser.py
+++ b/httpobs/tests/unittests/test_csp_parser.py
@@ -58,7 +58,6 @@ class TestContentSecurityPolicyParser(TestCase):
             'default-src': {"'none'"},
         })
 
-
         # a policy with four differing websites that should end up with 'none'
         policy = [
             "default-src https://mozilla.org https://mozilla.net",

--- a/httpobs/tests/unittests/test_csp_parser.py
+++ b/httpobs/tests/unittests/test_csp_parser.py
@@ -1,0 +1,121 @@
+from unittest import TestCase
+
+from httpobs.scanner.analyzer.headers import __parse_csp as parse_csp
+
+
+class TestContentSecurityPolicyParser(TestCase):
+    def test_csp_parser(self):
+        # one policy with one directive
+        policy = ["default-src 'none'"]
+
+        self.assertEquals(parse_csp(policy), {
+            'default-src': {"'none'"}
+        })
+
+        # one policy with multiple directives
+        policy = ["default-src 'none'; script-src 'self' https://mozilla.org"]
+        self.assertEquals(parse_csp(policy), {
+            'default-src': {"'none'"},
+            'script-src': {"'self'", 'https://mozilla.org'}
+        })
+
+        # two identical policies
+        policy = [
+            "default-src 'none'; script-src 'self' https://mozilla.org",
+            "default-src 'none'; script-src 'self' https://mozilla.org",
+        ]
+        self.assertEquals(parse_csp(policy), {
+            'default-src': {"'none'"},
+            'script-src': {"'self'", 'https://mozilla.org'}
+        })
+
+        # two policies, one of which has a source that isn't in the other
+        policy = [
+            "default-src 'none'; script-src 'self' https://mozilla.org",
+            "default-src 'none'; script-src 'self' https://mozilla.org https://example.com",
+        ]
+        self.assertEquals(parse_csp(policy), {
+            'default-src': {"'none'"},
+            'script-src': {"'self'", 'https://mozilla.org'}
+        })
+
+        # same thing as the previous policy, but the sources are in different orders
+        policy = [
+            "default-src 'none'; script-src 'self' https://mozilla.org",
+            "default-src 'none'; script-src https://example.com 'self' https://mozilla.org",
+        ]
+        self.assertEquals(parse_csp(policy), {
+            'default-src': {"'none'"},
+            'script-src': {"'self'", 'https://mozilla.org'}
+        })
+
+        # a policy with two differing websites that should end up with 'none'
+        policy = [
+            "default-src https://mozilla.org",
+            "default-src https://mozilla.com",
+        ]
+        self.assertEquals(parse_csp(policy), {
+            'default-src': {"'none'"},
+        })
+
+
+        # a policy with four differing websites that should end up with 'none'
+        policy = [
+            "default-src https://mozilla.org https://mozilla.net",
+            "default-src https://mozilla.com https://mozilla.io",
+        ]
+        self.assertEquals(parse_csp(policy), {
+            'default-src': {"'none'"},
+        })
+
+        # a policy with a bunch of websites, with only two in common
+        policy = [
+            "default-src https://mozilla.org https://mozilla.net https://mozilla.com https://mozilla.io",
+            "default-src https://mozilla.pizza https://mozilla.ninja https://mozilla.net https://mozilla.org",
+        ]
+        self.assertEquals(parse_csp(policy), {
+            'default-src': {"https://mozilla.net", "https://mozilla.org"},
+        })
+
+        # a four policies with a bunch of websites, with only two in common
+        policy = [
+            "default-src https://mozilla.org https://mozilla.net https://mozilla.com https://mozilla.io",
+            "default-src https://mozilla.pizza https://mozilla.ninja https://mozilla.net https://mozilla.org",
+            "default-src https://mozilla.net https://mozilla.fox https://mozilla.fire https://mozilla.org",
+            "default-src https://mozilla.browser https://mozilla.web https://mozilla.net https://mozilla.org",
+        ]
+        self.assertEquals(parse_csp(policy), {
+            'default-src': {"https://mozilla.net", "https://mozilla.org"},
+        })
+
+        # a policy with http: and https:, two differing sources that should end up with 'none'
+        policy = [
+            "default-src http:",
+            "default-src https:",
+        ]
+        self.assertEquals(parse_csp(policy), {
+            'default-src': {"'none'"},
+        })
+
+        # a policy with http: and https:, two differing sources that should end up with 'none'
+        policy = [
+            "default-src http: http:",
+            "default-src https: https:",
+        ]
+        self.assertEquals(parse_csp(policy), {
+            'default-src': {"'none'"},
+        })
+
+        # policies that are too short
+        policies = (
+            ["  "],
+            ["\r\n"],
+            ["\r\n\r\n\r\n\r\n\r\n\r\n"],
+            [""],
+            ["default-src 'none'; default-src 'none'"],  # Repeated directives not allowed
+            ["default-src 'none'; img-src 'self'; default-src 'none'"],
+            ["defa"],
+        )
+        for policy in policies:
+            with self.assertRaises(ValueError):
+                parse_csp(policy)

--- a/httpobs/tests/unittests/test_headers.py
+++ b/httpobs/tests/unittests/test_headers.py
@@ -255,7 +255,6 @@ class TestContentSecurityPolicy(TestCase):
         self.assertTrue(result['meta'])
         self.assertTrue(result['pass'])
 
-
     def test_strict_dynamic(self):
         values = (
             "default-src 'none'; script-src 'strict-dynamic' 'nonce-abc123'",

--- a/httpobs/tests/unittests/test_parse_http_equiv_headers.py
+++ b/httpobs/tests/unittests/test_parse_http_equiv_headers.py
@@ -13,19 +13,21 @@ class TestHTTPEquivHeaders(TestCase):
     def test_header_match(self):
         reqs = empty_requests('test_parse_http_equiv_headers_csp1.html')
 
-        self.assertEquals(reqs['responses']['auto'].http_equiv, {'Content-Security-Policy': 'default-src \'none\';'})
+        self.assertEquals(reqs['responses']['auto'].http_equiv,
+                          {'Content-Security-Policy': ['default-src \'none\';']})
 
     def test_header_case_insensitivity(self):
         reqs = empty_requests('test_parse_http_equiv_headers_csp1.html')
 
-        self.assertEquals(reqs['responses']['auto'].http_equiv['content-security-policy'], 'default-src \'none\';')
-        self.assertEquals(reqs['responses']['auto'].http_equiv['content-SECURITY-policy'], 'default-src \'none\';')
+        self.assertEquals(reqs['responses']['auto'].http_equiv['content-security-policy'], ['default-src \'none\';'])
+        self.assertEquals(reqs['responses']['auto'].http_equiv['content-SECURITY-policy'], ['default-src \'none\';'])
 
     def test_multiple_http_equivs(self):
         reqs = empty_requests('test_parse_http_equiv_headers_csp_multiple_http_equiv1.html')
 
-        self.assertEquals(reqs['responses']['auto'].http_equiv['Content-Security-Policy'],
-                          "default-src 'none'; object-src 'none'; media-src 'none';; connect-src 'self'; " +
-                          "font-src 'self'; child-src 'self'; img-src 'self'; style-src 'self' " +
-                          "'nonce-gAeQO8jI4VJCsrsXkcUVRCzQjiihKteQ; script-src 'self' 'unsafe-inline' " +
-                          "'nonce-gAeQO8jI4VJCsrsXkcUVRCzQjiihKteQ'")
+        self.assertEquals(reqs['responses']['auto'].http_equiv['Content-Security-Policy'], [
+            "default-src 'none'; object-src 'none'; media-src 'none';",
+            "connect-src 'self'; font-src 'self'; child-src 'self'",
+            "img-src 'self'; style-src 'self' 'nonce-gAeQO8jI4VJCsrsXkcUVRCzQjiihKteQ",
+            "script-src 'self' 'unsafe-inline' 'nonce-gAeQO8jI4VJCsrsXkcUVRCzQjiihKteQ'",
+        ])

--- a/httpobs/tests/utils.py
+++ b/httpobs/tests/utils.py
@@ -1,6 +1,9 @@
 from collections import UserDict
 from copy import deepcopy
 from requests.cookies import RequestsCookieJar
+from typing import Union
+from urllib3 import HTTPResponse
+from urllib3._collections import HTTPHeaderDict
 
 import os.path
 
@@ -19,7 +22,7 @@ def empty_requests(http_equiv_file=None) -> dict:
             '/robots.txt': None,
         },
         'responses': {
-            'auto': UserDict(),
+            'auto': HTTPResponse(),
             'cors': None,
             'http': None,
             'https': None,
@@ -41,6 +44,8 @@ def empty_requests(http_equiv_file=None) -> dict:
         'Content-Type': 'text/html',
     }
     req['responses']['auto'].history = []
+    req['responses']['auto'].raw = HTTPResponse()
+    req['responses']['auto'].raw.headers = HTTPHeaderDict()
     req['responses']['auto'].request = UserDict()
     req['responses']['auto'].request.headers = UserDict()
     req['responses']['auto'].status_code = 200
@@ -60,3 +65,13 @@ def empty_requests(http_equiv_file=None) -> dict:
         req['responses']['auto'].http_equiv = {}
 
     return req
+
+
+# if we want to handle multiple of the same header, we need to add it to both headers and raw headers
+def set_header(response: HTTPResponse, header: str, values: Union[str, list]):
+    if isinstance(values, str):
+        values = [values]
+
+    for value in values:
+        response.headers[header] = response.headers[header] + ', ' + value if header in response.headers else value
+        response.raw.headers.add(header, value)


### PR DESCRIPTION
Currently the Observatory can only handle a single CSP policy, delivered by HTTP header or HTTP equiv values.

This should let it parse multiple headers, regardless of how they are passed.