### PR TITLE
SRI: don't complain about data URIs

### DIFF
--- a/httpobs/scanner/analyzer/content.py
+++ b/httpobs/scanner/analyzer/content.py
@@ -170,6 +170,10 @@ def subresource_integrity(reqs: dict, expectation='sri-implemented-and-external-
                         # Relative protocol (src="//host/path")
                         relativeorigin = False
                         relativeprotocol = True
+                elif src.scheme == 'data':
+                    # Data URI is essentially the same as inline script, treat is as local path for simplicity
+                    relativeorigin = True
+                    relativeprotocol = True
                 else:
                     relativeorigin = False
                     relativeprotocol = False

--- a/httpobs/tests/unittests/files/test_content_sri_data_uri.html
+++ b/httpobs/tests/unittests/files/test_content_sri_data_uri.html
@@ -1,0 +1,6 @@
+<html>
+  <head>
+    <script src="data:text/javascript;base64,YWxlcnQoMSkK"></script>
+    <head>
+  <body></body>
+</html>

--- a/httpobs/tests/unittests/test_content.py
+++ b/httpobs/tests/unittests/test_content.py
@@ -195,6 +195,15 @@ class TestSubResourceIntegrity(TestCase):
         self.assertEquals('sri-not-implemented-but-all-scripts-loaded-from-secure-origin', result['result'])
         self.assertTrue(result['pass'])
 
+    def test_data_uri(self):
+        # load from a remote site
+        self.reqs = empty_requests('test_content_sri_data_uri.html')
+
+        result = subresource_integrity(self.reqs)
+
+        self.assertEquals('sri-not-implemented-but-all-scripts-loaded-from-secure-origin', result['result'])
+        self.assertTrue(result['pass'])
+
     def test_implemented_external_scripts_https(self):
         # load from a remote site
         self.reqs = empty_requests('test_content_sri_impl_external_https1.html')


### PR DESCRIPTION
Resolves #455 (also created by me, a year or so ago)

In short, `<script src="data:...">` is pretty much equivalent to an inline script, except that it can be `async`, `defer` or ES module. 
This PR whitelists `data` URI scheme as trusted, as Observatory currently considers it a script with insecure scheme, giving significant penalties for it.

The CI will fail, because it won't find Python 3.6, otherwise the tests should passed when I tried it.