### PR TITLE
Update Dockerfile

### DIFF
--- a/httpobs/Dockerfile
+++ b/httpobs/Dockerfile
@@ -1,6 +1,6 @@
 # http-observatory
 
-FROM python:3.5
+FROM python:3.7
 MAINTAINER https://github.com/mozilla/http-observatory
 
 RUN groupadd --gid 1001 app && \


### PR DESCRIPTION
Requirements can not be satisfied using the Python 3.5 image. Also Python 3.5 is end of life.