### PR TITLE
Fix: docker build

### DIFF
--- a/httpobs/Dockerfile
+++ b/httpobs/Dockerfile
@@ -1,6 +1,6 @@
 # http-observatory
 
-FROM python:3.5
+FROM python:3.6
 MAINTAINER https://github.com/mozilla/http-observatory
 
 RUN groupadd --gid 1001 app && \


### PR DESCRIPTION
It is necessary to update Dockerfile, at least python:3.6, because the `requests` 2.27.1 package is only compatible with it.