### PR TITLE
Separate dependencies into groups and extras

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,19 +2,22 @@
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.12.2"
+version = "4.12.3"
 description = "Screen-scraping library"
 optional = false
 python-versions = ">=3.6.0"
 files = [
-    {file = "beautifulsoup4-4.12.2-py3-none-any.whl", hash = "sha256:bd2520ca0d9d7d12694a53d44ac482d181b4ec1888909b035a3dbf40d0f57d4a"},
-    {file = "beautifulsoup4-4.12.2.tar.gz", hash = "sha256:492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da"},
+    {file = "beautifulsoup4-4.12.3-py3-none-any.whl", hash = "sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed"},
+    {file = "beautifulsoup4-4.12.3.tar.gz", hash = "sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051"},
 ]
 
 [package.dependencies]
 soupsieve = ">1.2"
 
 [package.extras]
+cchardet = ["cchardet"]
+chardet = ["chardet"]
+charset-normalizer = ["charset-normalizer"]
 html5lib = ["html5lib"]
 lxml = ["lxml"]
 
@@ -66,7 +69,7 @@ uvloop = ["uvloop (>=0.15.2)"]
 name = "blinker"
 version = "1.7.0"
 description = "Fast, simple object-to-object and broadcast signaling"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "blinker-1.7.0-py3-none-any.whl", hash = "sha256:c3f865d4d54db7abc53758a01601cf343fe55b84c1de4e3fa910e420b438d5b9"},
@@ -330,7 +333,7 @@ pyflakes = ">=3.1.0,<3.2.0"
 name = "flask"
 version = "3.0.0"
 description = "A simple framework for building complex web applications."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "flask-3.0.0-py3-none-any.whl", hash = "sha256:21128f47e4e3b9d597a3e8521a329bf56909b690fcc3fa3e477725aa81367638"},
@@ -391,7 +394,7 @@ colors = ["colorama (>=0.4.6)"]
 name = "itsdangerous"
 version = "2.1.2"
 description = "Safely pass data to untrusted environments and back."
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "itsdangerous-2.1.2-py3-none-any.whl", hash = "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44"},
@@ -402,7 +405,7 @@ files = [
 name = "jinja2"
 version = "3.1.3"
 description = "A very fast and expressive template engine."
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
@@ -419,7 +422,7 @@ i18n = ["Babel (>=2.7)"]
 name = "markupsafe"
 version = "2.1.3"
 description = "Safely add untrusted strings to HTML/XML markup."
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa"},
@@ -590,7 +593,7 @@ virtualenv = ">=20.10.0"
 name = "psycopg2"
 version = "2.9.9"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "psycopg2-2.9.9-cp310-cp310-win32.whl", hash = "sha256:38a8dcc6856f569068b47de286b472b7c473ac7977243593a288ebce0dc89516"},
@@ -610,13 +613,13 @@ files = [
 
 [[package]]
 name = "publicsuffixlist"
-version = "0.10.0.20231214"
+version = "0.10.0.20240108"
 description = "publicsuffixlist implement"
 optional = false
 python-versions = ">=2.6"
 files = [
-    {file = "publicsuffixlist-0.10.0.20231214-py2.py3-none-any.whl", hash = "sha256:10e227902e3b2acefb604b5de8a8a7d3df237f2885f06762d47fdbc9e0528b67"},
-    {file = "publicsuffixlist-0.10.0.20231214.tar.gz", hash = "sha256:76a2ed46814f091ea867fb40a6c20c142a437af7aae7ac8eb425ddc464bcb8e1"},
+    {file = "publicsuffixlist-0.10.0.20240108-py2.py3-none-any.whl", hash = "sha256:72ac774728036610501353789125a7adc57a793646cf6c6f1f7cc7458c913a8a"},
+    {file = "publicsuffixlist-0.10.0.20240108.tar.gz", hash = "sha256:2d15301cbef4b5ecc9bfa47b38959af73350915748d44b2f91db2a8fc3b98d24"},
 ]
 
 [package.extras]
@@ -783,7 +786,7 @@ zstd = ["zstandard (>=0.18.0)"]
 name = "uwsgi"
 version = "2.0.23"
 description = "The uWSGI server"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "uwsgi-2.0.23.tar.gz", hash = "sha256:0cafda0c16f921db7fe42cfaf81b167cf884ee17350efbdd87d1ecece2d7de37"},
@@ -813,7 +816,7 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 name = "werkzeug"
 version = "3.0.1"
 description = "The comprehensive WSGI web application library."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "werkzeug-3.0.1-py3-none-any.whl", hash = "sha256:90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10"},
@@ -826,7 +829,10 @@ MarkupSafe = ">=2.1.1"
 [package.extras]
 watchdog = ["watchdog (>=2.3)"]
 
+[extras]
+website = ["Flask", "psycopg2", "uWSGI"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "08b448fa537b520f27a5a642b51b5562e1eb126604da8f7d4bccd4459afa4fe7"
+content-hash = "bb00b804cb8d366d3c234acce3dfd6c5e1e374b9d02e6821d88e514fc2327956"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,18 @@ httpobs-regen-hsts-preload = "httpobs.scanner.utils:retrieve_store_hsts_preload_
 [tool.poetry.dependencies]
 python = "^3.11"
 beautifulsoup4 = "^4.12.2"
-flake8 = "^6.1.0"
-pep8 = "^1.7.1"
-psycopg2 = "^2.9.9"
+psycopg2 = { version = "^2.9.9", optional = true }
 publicsuffixlist = "^0.10.0.20231002"
 requests = "^2.31.0"
-Flask = "^3.0.0"
-uWSGI = "^2.0.22"
+Flask = { version = "^3.0.0", optional = true }
+uWSGI = { version = "^2.0.22", optional = true }
+
+[tool.poetry.extras]
+website = ["psycopg2", "Flask", "uWSGI"]
+
+[tool.poetry.group.dev.dependencies]
+pep8 = "^1.7.1"
+flake8 = "^6.1.0"
 pre-commit = "^3.6.0"
 black = "^23.12.1"
 isort = "^5.13.2"


### PR DESCRIPTION
This commits adds a new extra [website] that install the dependencies `psycopg2` `Flask` and `uWSGI`.
It also moves the dev dependencies into the dev group.

This will make it easier for developers to install the package from PyPi and use it as a library instead of using it as a web server.
If a developer wants to use the server it can do so by using the [website] extra.